### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+before_install:
+  - sudo apt-get install junit4
+  - mkdir ~/junit
+  - ln -s /usr/share/java/junit4.jar ~/junit
+  - ln -s /usr/share/java/hamcrest-core.jar ~/junit
+  - export JUNIT_HOME=~/junit
+install: ant test
+jdk:
+  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
This adds Travis CI config file to automatically build against OracleJDK8, OpenJDK8. 

One of the org admins need [enable](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI) this repo in travis-ci.org, for build statuses to be shown up on commits, and PRs. 

Fixes: #2 