### PR TITLE
Fix incorrect IncompatibleClassChangeError in ClassInfo.getDefaultMethod

### DIFF
--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -1095,7 +1095,7 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
       for (ClassInfo ciIfc : ci.interfaces){
         MethodInfo miIfc = ciIfc.getMethod(uniqueName, true);
         if (miIfc != null && !miIfc.isAbstract()){
-          if (mi != null){
+          if (mi != null && !mi.equals(miIfc)){
             // this has to throw a IncompatibleClassChangeError in the client since Java prohibits ambiguous default methods
             String msg = "Conflicting default methods: " + mi.getFullName() + ", " + miIfc.getFullName();
             throw new ClassChangeException(msg);

--- a/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
@@ -255,4 +255,24 @@ public class MethodTest extends TestMethodBase {
       assert a.foo() == 1 : "wrong A.foo() called for A1";
     }
   }
+
+
+  interface InterfaceWithDefaultMethod {
+    default int foo() {
+      return 42;
+    }
+  }
+
+  static class Base implements InterfaceWithDefaultMethod {
+  }
+
+  static class Child extends Base implements InterfaceWithDefaultMethod {
+  }
+
+  @Test
+  public void testDefaultMethodCall() {
+    if (verifyNoPropertyViolation()) {
+      assertEquals(42, new Child().foo());
+    }
+  }
 }


### PR DESCRIPTION
The logic to detect if there are two conflicting default methods was incorrect.
If a class and its superclass both implement the same interface JPF should not
throw an IncompatibleClassChangeError.