### PR TITLE
Make Travis build against latest available oracle-jdk 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: java
 before_install:
-  - sudo apt-get install junit4
   - mkdir ~/junit
   - ln -s /usr/share/java/junit4.jar ~/junit
   - ln -s /usr/share/java/hamcrest-core.jar ~/junit
   - export JUNIT_HOME=~/junit
+
 install: ant test
+
 jdk:
   - oraclejdk8
-  - openjdk8
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+      - junit4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+before_install:
+  - sudo apt-get install junit4
+  - mkdir ~/junit
+  - ln -s /usr/share/java/junit4.jar ~/junit
+  - ln -s /usr/share/java/hamcrest-core.jar ~/junit
+  - export JUNIT_HOME=~/junit
+install: ant test
+jdk:
+  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
jpf-core requires a newer release of Oracle JDK than the pre-installed version provided by the Travis. This will make Travic CI to use the latest available oracle-jdk that is provided from the PPA oracle-java8-installer.

References:
https://docs.travis-ci.com/user/languages/java/#Updating-Oracle-JDK-to-a-recent-release