### PR TITLE
Remove unused import com.sun.org.apache.bcel.internal.generic.InstructionConstants

### DIFF
--- a/src/main/gov/nasa/jpf/vm/MJIEnv.java
+++ b/src/main/gov/nasa/jpf/vm/MJIEnv.java
@@ -17,7 +17,6 @@
  */
 package gov.nasa.jpf.vm;
 
-import com.sun.org.apache.bcel.internal.generic.InstructionConstants;
 import gov.nasa.jpf.Config;
 import gov.nasa.jpf.JPF;
 import gov.nasa.jpf.JPFException;


### PR DESCRIPTION
Fixes the compile error:
    error: package com.sun.org.apache.bcel.internal.generic does not exist

Fixes: #19