### PR TITLE
Refactor references to sun.reflect.ConstantPool

### DIFF
--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -32,7 +32,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import sun.reflect.ConstantPool;
+import jdk.internal.reflect.ConstantPool;
 import sun.reflect.annotation.AnnotationType;
 
 /**

--- a/src/classes/modules/java.base/java/lang/System.java
+++ b/src/classes/modules/java.base/java/lang/System.java
@@ -26,7 +26,7 @@ import java.util.Properties;
 import sun.misc.JavaLangAccess;
 import sun.misc.SharedSecrets;
 import sun.nio.ch.Interruptible;
-import sun.reflect.ConstantPool;
+import jdk.internal.reflect.ConstantPool;
 import sun.reflect.annotation.AnnotationType;
 
 

--- a/src/classes/modules/java.base/jdk/internal/misc/JavaLangAccess.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/JavaLangAccess.java
@@ -19,7 +19,7 @@
 package jdk.internal.misc;
 
 import sun.nio.ch.Interruptible;
-import sun.reflect.ConstantPool;
+import jdk.internal.reflect.ConstantPool;
 import sun.reflect.annotation.AnnotationType;
 
 /**


### PR DESCRIPTION
This fixes:

```
[javac] classes/modules/java.base/java/lang/System.java: error: cannot find symbol
[javac] import sun.reflect.ConstantPool;
```

```
[javac] classes/modules/java.base/java/lang/Class.java:274: error: cannot find symbol
[javac] native ConstantPool getConstantPool();
```

Fixes: #29