### PR TITLE
Refactor references to sun.misc.SharedSecrets

### DIFF
--- a/src/classes/modules/java.base/java/lang/System.java
+++ b/src/classes/modules/java.base/java/lang/System.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import sun.misc.JavaLangAccess;
-import sun.misc.SharedSecrets;
+import jdk.internal.misc.SharedSecrets;
 import sun.nio.ch.Interruptible;
 import sun.reflect.ConstantPool;
 import sun.reflect.annotation.AnnotationType;

--- a/src/classes/modules/java.base/sun/reflect/annotation/AnnotationType.java
+++ b/src/classes/modules/java.base/sun/reflect/annotation/AnnotationType.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import sun.misc.SharedSecrets;
+import jdk.internal.misc.SharedSecrets;
 
 /**
  * this is a placeholder for a Java 6 class, which we only have here to


### PR DESCRIPTION
This fixes:

```
[javac] src/classes/modules/java.base/sun/reflect/annotation/AnnotationType.java:28: error: cannot find symbol
[javac] import sun.misc.SharedSecrets;
[javac]                ^
[javac]   symbol:   class SharedSecrets
[javac]   location: package sun.misc
```

```
[javac] src/classes/modules/java.base/java/lang/System.java:27: error: cannot find symbol
[javac] import sun.misc.SharedSecrets;
[javac]                ^
[javac]   symbol:   class SharedSecrets
[javac]   location: package sun.misc
```

```
[javac] src/classes/modules/java.base/sun/reflect/annotation/AnnotationType.java:52: error: cannot find symbol
[javac]     AnnotationType at = SharedSecrets.getJavaLangAccess().getAnnotationType(annotationClass);
[javac]                         ^
[javac]   symbol:   variable SharedSecrets
[javac]   location: class AnnotationType
```

```
[javac] src/classes/modules/java.base/sun/reflect/annotation/AnnotationType.java:97: error: cannot find symbol
[javac]     SharedSecrets.getJavaLangAccess().setAnnotationType(annoCls, this);
[javac]     ^
[javac]   symbol:   variable SharedSecrets
[javac]   location: class AnnotationType
```

```
[javac] src/classes/modules/java.base/java/lang/System.java:61: error: cannot find symbol
[javac]     SharedSecrets.setJavaLangAccess( createJavaLangAccess());
[javac]     ^
[javac]   symbol:   variable SharedSecrets
[javac]   location: class System
```

Fixes: #31