### PR TITLE
Remove unused import sun.misc.CompoundEnumeration

### DIFF
--- a/src/classes/modules/java.base/java/lang/ClassLoader.java
+++ b/src/classes/modules/java.base/java/lang/ClassLoader.java
@@ -26,8 +26,6 @@ import java.security.ProtectionDomain;
 import java.util.Enumeration;
 import java.util.Vector;
 
-import sun.misc.CompoundEnumeration;
-
 /**
  * @author Nastaran Shafiei <nastaran.shafiei@gmail.com>
  * 


### PR DESCRIPTION
Import sun.misc.CompoundEnumeration is unused in modules/java.base/java/lang/ClassLoader.java

And also ClassLoader and CompoundEnumeration both belongs to the same package, java.lang.
And we don't have any model class that overrides it.

Thus it is not required that we explicitly import it.

Fixes: #35