### PR TITLE
Remove JavaOISAccess from model class SharedSecrets

### DIFF
--- a/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
@@ -57,7 +57,6 @@ public class SharedSecrets {
   private static JavaIOFileDescriptorAccess javaIOFileDescriptorAccess;
   private static JavaNioAccess javaNioAccess;
   private static JavaAWTAccess javaAWTAccess;
-  private static JavaOISAccess javaOISAccess;
   private static JavaObjectInputStreamAccess javaObjectInputStreamAccess;
 
   // (required for EnumSet ops)
@@ -159,16 +158,4 @@ public class SharedSecrets {
     return javaAWTAccess;
   }
 
-  public static void setJavaOISAccess(JavaOISAccess access) {
-    javaOISAccess = access;
-  }
-
-  public static JavaOISAccess getJavaOISAccess() {
-    if (javaOISAccess == null) {
-      unsafe.ensureClassInitialized(ObjectInputStream.class);
-      throw new UnsupportedOperationException("sun.misc.SharedSecrets.getJavaOISAccess() not supported yet");
-    }
-
-    return javaOISAccess;
-  }
 }


### PR DESCRIPTION
This removes JavaOISAccess static field and accessor methods from
classes/modules/java.base/jdk/internal/misc/SharedSecrets.java

This fixes errors:
```
src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java:60: error: cannot find symbol
[javac]   private static JavaOISAccess javaOISAccess;
[javac]                  ^

src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java:162: error: cannot find symbol
[javac]   public static void setJavaOISAccess(JavaOISAccess access) {
[javac]                                       ^

src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java:166: error: cannot find symbol
[javac]   public static JavaOISAccess getJavaOISAccess() {
[javac]                 ^
```
Fixes: #38