### PR TITLE
Refactor references to URLClassPath

### DIFF
--- a/src/classes/modules/java.base/jdk/internal/misc/JavaNetAccess.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/JavaNetAccess.java
@@ -19,6 +19,7 @@
 package jdk.internal.misc;
 
 import java.net.URLClassLoader;
+import jdk.internal.loader.URLClassPath;
 
 /**
  * this is a placeholder for a Java 6 class, which we only have here to


### PR DESCRIPTION
sun.misc.URLClassPath has been moved to the internal package:
java.base/jdk.internal.loader.URLClassPath

This fixes:

    classes/modules/java.base/jdk/internal/misc/JavaNetAccess.java: error: cannot find symbol
    [javac]   URLClassPath getURLClassPath (URLClassLoader ucl);
    [javac]   symbol:   class URLClassPath
    [javac]   location: interface JavaNetAccess

Fixes: #41