### PR TITLE
Format output of ant 'test' target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -442,7 +442,7 @@
       </not>
     </condition>
     
-    <junit printsummary="on" showoutput="off" 
+    <junit printsummary="on" showoutput="on"
            haltonfailure="no" logfailedtests="true" failureproperty="test.failed" 
            dir="${basedir}" fork="yes" forkmode="perTest" maxmemory="1024m" outputtoformatters="true">
       <formatter type="plain" usefile="${junit.usefile}"/>

--- a/build.xml
+++ b/build.xml
@@ -443,7 +443,7 @@
     </condition>
     
     <junit printsummary="on" showoutput="on"
-           haltonfailure="no" logfailedtests="true" failureproperty="test.failed" 
+           haltonfailure="yes" logfailedtests="true" failureproperty="test.failed"
            dir="${basedir}" fork="yes" forkmode="perTest" maxmemory="1024m" outputtoformatters="true">
       <formatter type="plain" usefile="${junit.usefile}"/>
 


### PR DESCRIPTION
This modifies the JUnit output of ant target 'test'
- Send tests output to Ant's logging system 
- Stop the build process if a test fails 
