### PR TITLE
Disable Xlint:deprecation when compiling sources

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
   
   <!-- compiler settings -->
   <property name="debug"         value="on"/>
-  <property name="deprecation"   value="on"/>
+  <property name="deprecation"   value="off"/>
 
   <uptodate property="build_uptodate" targetfile="build/main/gov/nasa/jpf/build.properties" srcfile="build.properties"/>
 
@@ -106,7 +106,7 @@
     <mkdir dir="build/peers"/>
     <javac srcdir="src/peers" destdir="build/peers" includeantruntime="false"
            debug="${debug}" deprecation="${deprecation}" classpathref="lib.path">
-      <compilerarg value="-Xlint:all,-serial"/>
+      <compilerarg value="-Xlint:all,-serial,-deprecation"/>
      </javac>
   </target>
   
@@ -116,7 +116,7 @@
     <!-- compile non-module classes -->
     <javac srcdir="src/classes/gov:src/classes/org" destdir="build/classes" includeantruntime="false"
            debug="${debug}" deprecation="${deprecation}" classpathref="lib.path">
-      <compilerarg value="-Xlint:all"/>
+      <compilerarg value="-Xlint:all,-deprecation"/>
 
       <compilerarg value="--patch-module"/>
       <compilerarg value="java.base=src/classes/modules/java.base"/>
@@ -134,7 +134,7 @@
     <!-- patch model classes -->
     <javac modulesourcepath="src/classes/modules" destdir="build/classes" includeantruntime="false"
            debug="${debug}" deprecation="${deprecation}" classpathref="lib.path">
-      <compilerarg value="-Xlint:all"/>
+      <compilerarg value="-Xlint:all,-deprecation"/>
 
       <compilerarg value="--patch-module"/>
       <compilerarg value="java.base=src/classes/modules/java.base"/>
@@ -156,7 +156,7 @@
     <javac sourcepath="" srcdir="src/tests" destdir="build/tests" includeantruntime="false"
            debug="${debug}" deprecation="${deprecation}"
            includes="*,gov/nasa/jpf/**,classloader_specific_tests/**">
-      <compilerarg value="-Xlint:all,-serial,-rawtypes,-unchecked"/>
+      <compilerarg value="-Xlint:all,-serial,-rawtypes,-unchecked,-deprecation"/>
 
       <include name="*gov/nasa/jpf/**"/>
       <include name="classloader_specific_tests/**"/>


### PR DESCRIPTION
Temporarily disable Xlint:deprecation just to reduce the verbosity of the build logs.

eg:-  warning: [deprecation] Integer(int) in Integer has been deprecated