### PR TITLE
Rearrange class files in jpf-classes.jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -197,10 +197,6 @@
     <copy file=".version" todir="build/main/gov/nasa/jpf" failonerror="false"/>
 
     <jar jarfile="build/jpf-classes.jar">
-      <fileset dir="build/classes">
-        <include name="gov/nasa/jpf/*.class"/>
-        <include name="org/junit/*.class"/>
-      </fileset>
       <fileset dir="build/classes/java.base"/>
       <fileset dir="build/classes/java.logging"/>
 


### PR DESCRIPTION
Before Java module system (introduced in JDK 9), once compiled, all compiled classes are nested inside the destination directory, based on their respective packages. So for instance,

```
build/classes/
├── java
│   ├── io
│   ├── lang
│   │   ├── annotation
│   │   ├── ref
│   │   └── reflect
```

But when compiled with Java 9/10, directory structure of the destination directory for the generated class files is as follows.

```
build/classes/
├── java.base
│   ├── java
│   │   ├── io
│   │   ├── lang
│   │   │   ├── annotation
│   │   │   ├── ref
│   │   │   └── reflect
```

So if we are to include classes from build/classes directory as a fileset into jpf-classes.jar, as done previously, like:
    <jar jarfile="build/jpf-classes.jar">
      <fileset dir="build/classes"/>

.. JPF classloader will fail to resolve the model classes, because the class urls are different than previously.

```
[junit] gov.nasa.jpf.vm.ClassInfoException: class not found: java.lang.Object
 at gov.nasa.jpf.vm.ClassLoaderInfo.getResolvedClassInfo(ClassLoaderInfo.java:363)
 at gov.nasa.jpf.vm.SystemClassLoaderInfo.getResolvedClassInfo(SystemClassLoaderInfo.java:147)
 [SEVERE] cannot load system class java.lang.Object
```

So this restructure the files in jpf-classes.jar (same as before) without introducing any implementation changes to the code.

Fixes: #50