### PR TITLE
Fix warnings caused by deprecated constructor calls with primitive argument

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/ClassFile.java
+++ b/src/main/gov/nasa/jpf/jvm/ClassFile.java
@@ -955,7 +955,7 @@ public class ClassFile extends BinaryClassSource {
           dataIdx[i] = j++;
 
           int iVal = (data[j++]&0xff)<<24 | (data[j++]&0xff)<<16 | (data[j++]&0xff)<<8 | (data[j++]&0xff);
-          values[i] = new Integer(iVal);
+          values[i] = iVal;
           break;
 
         case CONSTANT_FLOAT:  // Float_info  { u1 tag; u4 bytes; }
@@ -963,14 +963,14 @@ public class ClassFile extends BinaryClassSource {
 
           int iBits = (data[j++]&0xff)<<24 | (data[j++]&0xff)<<16 | (data[j++]&0xff)<<8 | (data[j++]&0xff);
           float fVal = Float.intBitsToFloat(iBits);
-          values[i] = new Float(fVal);
+          values[i] = fVal;
           break;
 
         case CONSTANT_LONG:  // Long_info { u1 tag; u4 high_bytes; u4 low_bytes; }
           dataIdx[i] = j++;
           long lVal =  (data[j++]&0xffL)<<56 | (data[j++]&0xffL)<<48 | (data[j++]&0xffL)<<40 | (data[j++]&0xffL)<<32
                     | (data[j++]&0xffL)<<24 | (data[j++]&0xffL)<<16 | (data[j++]&0xffL)<<8 | (data[j++]&0xffL);
-          values[i] = new Long(lVal);
+          values[i] = lVal;
 
           dataIdx[++i] = -1;  // 8 byte cpValue occupy 2 index slots
           break;
@@ -981,7 +981,7 @@ public class ClassFile extends BinaryClassSource {
           long lBits = (data[j++]&0xffL)<<56 | (data[j++]&0xffL)<<48 | (data[j++]&0xffL)<<40 | (data[j++]&0xffL)<<32
                     | (data[j++]&0xffL)<<24 | (data[j++]&0xffL)<<16 | (data[j++]&0xffL)<<8 | (data[j++]&0xffL);
           double dVal = Double.longBitsToDouble(lBits);
-          values[i] = new Double(dVal);
+          values[i] = dVal;
 
           dataIdx[++i] = -1;  // 8 byte cpValue occupy 2 index slots
           break;

--- a/src/main/gov/nasa/jpf/jvm/JVMNativeStackFrame.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMNativeStackFrame.java
@@ -70,33 +70,33 @@ public class JVMNativeStackFrame extends NativeStackFrame {
 
       case Types.T_SHORT:
         ival = callerFrame.peek(stackOffset);
-        a[j] = new Short((short) ival);
+        a[j] = (short) ival;
 
         break;
 
       case Types.T_INT:
         ival = callerFrame.peek(stackOffset);
-        a[j] = new Integer(ival);
+        a[j] = ival;
 
         break;
 
       case Types.T_LONG:
         lval = callerFrame.peekLong(stackOffset);
         stackOffset++; // 2 stack words
-        a[j] = new Long(lval);
+        a[j] = lval;
 
         break;
 
       case Types.T_FLOAT:
         ival = callerFrame.peek(stackOffset);
-        a[j] = new Float(Types.intToFloat(ival));
+        a[j] = Types.intToFloat(ival);
 
         break;
 
       case Types.T_DOUBLE:
         lval = callerFrame.peekLong(stackOffset);
         stackOffset++; // 2 stack words
-        a[j] = new Double(Types.longToDouble(lval));
+        a[j] = Types.longToDouble(lval);
 
         break;
 
@@ -104,7 +104,7 @@ public class JVMNativeStackFrame extends NativeStackFrame {
         // NOTE - we have to store T_REFERENCE as an Integer, because
         // it shows up in our native method as an 'int'
         ival = callerFrame.peek(stackOffset);
-        a[j] = new Integer(ival);
+        a[j] = ival;
       }
 
       stackOffset++;
@@ -114,10 +114,10 @@ public class JVMNativeStackFrame extends NativeStackFrame {
     a[0] = ti.getMJIEnv();
     
     if (nmi.isStatic()) {
-      a[1] = new Integer( nmi.getClassInfo().getClassObjectRef());
+      a[1] = nmi.getClassInfo().getClassObjectRef();
     } else {
       int thisRef = callerFrame.getCalleeThis(nmi);
-      a[1] = new Integer( thisRef);
+      a[1] = thisRef;
       
       setThis(thisRef);
     }

--- a/src/main/gov/nasa/jpf/jvm/bytecode/DRETURN.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/DRETURN.java
@@ -40,7 +40,7 @@ public class DRETURN extends LongReturn {
       ret = frame.peekLong();
     }
 
-    return new Double(Types.longToDouble(ret));
+    return Types.longToDouble(ret);
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/jvm/bytecode/FRETURN.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/FRETURN.java
@@ -60,7 +60,7 @@ public class FRETURN extends JVMReturnInstruction {
       ret = frame.peekFloat();
     }
     
-    return new Float(ret);
+    return ret;
   }
   
   @Override

--- a/src/main/gov/nasa/jpf/jvm/bytecode/IRETURN.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/IRETURN.java
@@ -60,7 +60,7 @@ public class IRETURN extends JVMReturnInstruction {
       ret = frame.peek();
     }
 
-    return new Integer(ret);
+    return ret;
   }
   
   @Override

--- a/src/main/gov/nasa/jpf/jvm/bytecode/LRETURN.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/LRETURN.java
@@ -38,7 +38,7 @@ public class LRETURN extends LongReturn {
       ret = frame.peekLong();
     }
 
-    return new Long(ret);
+    return ret;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/listener/DeadlockAnalyzer.java
+++ b/src/main/gov/nasa/jpf/listener/DeadlockAnalyzer.java
@@ -96,7 +96,7 @@ public class DeadlockAnalyzer extends ListenerAdapter {
     }
 
     void printLocOn (PrintWriter pw) {
-      pw.print(String.format("%6d", new Integer(stateId)));
+      pw.print(String.format("%6d", stateId));
       
       if (insn != null) {
         pw.print(String.format(" %18.18s ", insn.getMnemonic()));

--- a/src/main/gov/nasa/jpf/listener/Perturbator.java
+++ b/src/main/gov/nasa/jpf/listener/Perturbator.java
@@ -367,7 +367,7 @@ public class Perturbator extends ListenerAdapter {
           // pop the callee stackframe and modify the caller stackframe
           // note that we don't need to enter in order to get the perturbation base
           // value because its already on the operand stack
-          ChoiceGenerator<?> cg = e.perturbator.createChoiceGenerator("perturbReturn", ti.getTopFrame(), new Integer(0));
+          ChoiceGenerator<?> cg = e.perturbator.createChoiceGenerator("perturbReturn", ti.getTopFrame(), 0);
           if (ss.setNextChoiceGenerator(cg)){
             ti.skipInstruction(insnToExecute);
           }
@@ -434,7 +434,7 @@ public class Perturbator extends ListenerAdapter {
             }
 
           } else { // first time around, create&set the CG and reexecute
-            ChoiceGenerator<?> cg = p.perturbator.createChoiceGenerator( "perturbGetField", frame, new Integer(0));
+            ChoiceGenerator<?> cg = p.perturbator.createChoiceGenerator( "perturbGetField", frame, 0);
             if (ss.setNextChoiceGenerator(cg)){
               assert savedFrame != null;
               // we could more efficiently restore the stackframe

--- a/src/main/gov/nasa/jpf/util/DynamicIntArray.java
+++ b/src/main/gov/nasa/jpf/util/DynamicIntArray.java
@@ -49,7 +49,7 @@ public final class DynamicIntArray implements Iterable<Integer> {
 
     @Override
 	public Integer next() {
-      return new Integer(get(i++));
+      return get(i++);
     }
 
     @Override

--- a/src/main/gov/nasa/jpf/util/SimplePool.java
+++ b/src/main/gov/nasa/jpf/util/SimplePool.java
@@ -164,20 +164,20 @@ public class SimplePool<E> {
   public static void main(String[] args) {
     SimplePool<Integer> pool = new SimplePool<Integer>(4);
     for (int i = 0; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o != p) throw new RuntimeException();
       Integer q = pool.pool(p);
       if (q != p) throw new RuntimeException();
     }
     for (int i = 0; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o == p) throw new RuntimeException();
       if (!o.equals(p)) throw new RuntimeException();
     }
     for (int i = 1; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o != p) throw new RuntimeException();
     }

--- a/src/main/gov/nasa/jpf/util/SparseObjVector.java
+++ b/src/main/gov/nasa/jpf/util/SparseObjVector.java
@@ -211,7 +211,7 @@ public class SparseObjVector<E> {
     
     // add some
     for (int i = -4200; i < 4200; i += 10) {
-      vect.set(i, new Integer(i));
+      vect.set(i, i);
     }
     
     // check for added & non-added
@@ -230,7 +230,7 @@ public class SparseObjVector<E> {
     
     // add some more
     for (int i = -4201; i < 4200; i += 10) {
-      vect.set(i, new Integer(i));
+      vect.set(i, i);
     }
 
     // check all added
@@ -268,10 +268,10 @@ public class SparseObjVector<E> {
 
     // add even more
     for (int i = -4203; i < 4200; i += 10) {
-      vect.set(i, new Integer(i));
+      vect.set(i, i);
     }
     for (int i = -4204; i < 4200; i += 10) {
-      vect.set(i, new Integer(i));
+      vect.set(i, i);
     }
   }
 }

--- a/src/main/gov/nasa/jpf/util/WeakPool.java
+++ b/src/main/gov/nasa/jpf/util/WeakPool.java
@@ -193,20 +193,20 @@ public class WeakPool<E> {
   public static void main(String[] args) {
     WeakPool<Integer> pool = new WeakPool<Integer>(4);
     for (int i = 0; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o != p) throw new RuntimeException();
       Integer q = pool.pool(p);
       if (q != p) throw new RuntimeException();
     }
     for (int i = 0; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o == p) throw new RuntimeException();
       if (!o.equals(p)) throw new RuntimeException();
     }
     for (int i = 1; i < 1000000; i += 42) {
-      Integer o = new Integer(i);
+      Integer o = i;
       Integer p = pool.pool(o);
       if (o != p) throw new RuntimeException();
     }

--- a/src/main/gov/nasa/jpf/vm/BooleanFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/BooleanFieldInfo.java
@@ -55,7 +55,7 @@ public class BooleanFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     int i = f.getIntValue(storageOffset);
-    return new Boolean(i != 0);
+    return i != 0;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/ByteFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ByteFieldInfo.java
@@ -63,7 +63,7 @@ public class ByteFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     int i = f.getIntValue(storageOffset);
-    return new Byte((byte)i);
+    return (byte) i;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/CharFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/CharFieldInfo.java
@@ -64,7 +64,7 @@ public class CharFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     int i = f.getIntValue(storageOffset);
-    return new Character((char)i);
+    return (char) i;
   }
 
 }

--- a/src/main/gov/nasa/jpf/vm/DoubleFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/DoubleFieldInfo.java
@@ -67,7 +67,7 @@ public class DoubleFieldInfo extends DoubleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     double d = f.getDoubleValue(storageOffset);
-    return new Double(d);
+    return d;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/FloatFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/FloatFieldInfo.java
@@ -61,7 +61,7 @@ public class FloatFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     float v = f.getFloatValue(storageOffset);
-    return new Float(v);
+    return v;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/IntegerFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/IntegerFieldInfo.java
@@ -62,7 +62,7 @@ public class IntegerFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     int i = f.getIntValue(storageOffset);
-    return new Integer(i);
+    return i;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/LongFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/LongFieldInfo.java
@@ -66,7 +66,7 @@ public class LongFieldInfo extends DoubleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     long v = f.getLongValue(storageOffset);
-    return new Long(v);
+    return v;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/MJIEnv.java
+++ b/src/main/gov/nasa/jpf/vm/MJIEnv.java
@@ -844,31 +844,31 @@ public class MJIEnv {
   }
 
   public Byte getByteObject (int objref){
-    return new Byte(getByteField(objref, "value"));
+    return getByteField(objref, "value");
   }
 
   public Character getCharObject (int objref){
-    return new Character(getCharField(objref, "value"));
+    return getCharField(objref, "value");
   }
 
   public Short getShortObject (int objref){
-    return new Short(getShortField(objref, "value"));
+    return getShortField(objref, "value");
   }
 
   public Integer getIntegerObject (int objref){
-    return new Integer(getIntField(objref, "value"));
+    return getIntField(objref, "value");
   }
 
   public Long getLongObject (int objref){
-    return new Long(getLongField(objref, "value"));
+    return getLongField(objref, "value");
   }
 
   public Float getFloatObject (int objref){
-    return new Float(getFloatField(objref, "value"));
+    return getFloatField(objref, "value");
   }
 
   public Double getDoubleObject (int objref){
-    return new Double(getDoubleField(objref, "value"));
+    return getDoubleField(objref, "value");
   }
 
   // danger - the returned arrays could be used to modify contents of stored objects

--- a/src/main/gov/nasa/jpf/vm/NativeMethodInfo.java
+++ b/src/main/gov/nasa/jpf/vm/NativeMethodInfo.java
@@ -235,33 +235,33 @@ public class NativeMethodInfo extends MethodInfo {
 
       case Types.T_SHORT:
         ival = caller.peek(stackOffset);
-        a[j] = new Short((short) ival);
+        a[j] = (short) ival;
 
         break;
 
       case Types.T_INT:
         ival = caller.peek(stackOffset);
-        a[j] = new Integer(ival);
+        a[j] = ival;
 
         break;
 
       case Types.T_LONG:
         lval = caller.peekLong(stackOffset);
         stackOffset++; // 2 stack words
-        a[j] = new Long(lval);
+        a[j] = lval;
 
         break;
 
       case Types.T_FLOAT:
         ival = caller.peek(stackOffset);
-        a[j] = new Float(Types.intToFloat(ival));
+        a[j] = Types.intToFloat(ival);
 
         break;
 
       case Types.T_DOUBLE:
         lval = caller.peekLong(stackOffset);
         stackOffset++; // 2 stack words
-        a[j] = new Double(Types.longToDouble(lval));
+        a[j] = Types.longToDouble(lval);
 
         break;
 
@@ -269,7 +269,7 @@ public class NativeMethodInfo extends MethodInfo {
         // NOTE - we have to store T_REFERENCE as an Integer, because
         // it shows up in our native method as an 'int'
         ival = caller.peek(stackOffset);
-        a[j] = new Integer(ival);
+        a[j] = ival;
       }
 
       stackOffset++;
@@ -277,9 +277,9 @@ public class NativeMethodInfo extends MethodInfo {
 
     //--- set  our standard MJI header arguments
     if (isStatic()) {
-      a[1] = new Integer(ci.getClassObjectRef());
+      a[1] = ci.getClassObjectRef();
     } else {
-      a[1] = new Integer(ti.getCalleeThis(this));
+      a[1] = ti.getCalleeThis(this);
     }
 
     a[0] = ti.getMJIEnv();

--- a/src/main/gov/nasa/jpf/vm/ShortFieldInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ShortFieldInfo.java
@@ -62,7 +62,7 @@ public class ShortFieldInfo extends SingleSlotFieldInfo {
   @Override
   public Object getValueObject (Fields f){
     int i = f.getIntValue(storageOffset);
-    return new Short((short)i);
+    return (short) i;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/StackFrame.java
+++ b/src/main/gov/nasa/jpf/vm/StackFrame.java
@@ -244,19 +244,19 @@ public abstract class StackFrame implements Cloneable {
         case 'Z':
           return Boolean.valueOf(v != 0);
         case 'B':
-          return new Byte((byte) v);
+          return (byte) v;
         case 'C':
-          return new Character((char) v);
+          return (char) v;
         case 'S':
-          return new Short((short) v);
+          return (short) v;
         case 'I':
-          return new Integer(v);
+          return v;
         case 'J':
-          return new Long(Types.intsToLong(slots[slotIdx + 1], v)); // Java is big endian, Types expects low,high
+          return Types.intsToLong(slots[slotIdx + 1], v); // Java is big endian, Types expects low,high
         case 'F':
-          return new Float(Float.intBitsToFloat(v));
+          return Float.intBitsToFloat(v);
         case 'D':
-          return new Double(Double.longBitsToDouble(Types.intsToLong(slots[slotIdx + 1], v)));
+          return Double.longBitsToDouble(Types.intsToLong(slots[slotIdx + 1], v));
         default:  // reference
           if (v >= 0) {
             return VM.getVM().getHeap().get(v);
@@ -911,36 +911,36 @@ public abstract class StackFrame implements Cloneable {
         break;
 
       case Types.T_LONG:
-        args[i] = new Long(peekLong(off));
+        args[i] = peekLong(off);
         off+=2;
         break;
       case Types.T_DOUBLE:
-        args[i] = new Double(Types.longToDouble(peekLong(off)));
+        args[i] = Types.longToDouble(peekLong(off));
         off+=2;
         break;
 
       case Types.T_BOOLEAN:
-        args[i] = new Boolean(peek(off) != 0);
+        args[i] = peek(off) != 0;
         off++;
         break;
       case Types.T_BYTE:
-        args[i] = new Byte((byte)peek(off));
+        args[i] = (byte) peek(off);
         off++;
         break;
       case Types.T_CHAR:
-        args[i] = new Character((char)peek(off));
+        args[i] = (char) peek(off);
         off++;
         break;
       case Types.T_SHORT:
-        args[i] = new Short((short)peek(off));
+        args[i] = (short) peek(off);
         off++;
         break;
       case Types.T_INT:
-        args[i] = new Integer(peek(off));
+        args[i] = peek(off);
         off++;
         break;
       case Types.T_FLOAT:
-        args[i] = new Float(Types.intToFloat(peek(off)));
+        args[i] = Types.intToFloat(peek(off));
         off++;
         break;
       default:

--- a/src/main/gov/nasa/jpf/vm/choice/DoubleChoiceFromList.java
+++ b/src/main/gov/nasa/jpf/vm/choice/DoubleChoiceFromList.java
@@ -46,12 +46,12 @@ public class DoubleChoiceFromList extends NumberChoiceFromList<Double> implement
   @Override
   protected Double parseLiteral(String literal, int sign) {
     double val = Double.parseDouble(literal);
-    return new Double(val * sign);
+    return val * sign;
   }
 
   @Override
   protected Double newValue(Number num, int sign) {
-    return new Double(num.intValue() * sign);
+    return (double) (num.intValue() * sign);
   }
 
   /**

--- a/src/main/gov/nasa/jpf/vm/choice/DoubleThresholdGenerator.java
+++ b/src/main/gov/nasa/jpf/vm/choice/DoubleThresholdGenerator.java
@@ -63,9 +63,9 @@ public class DoubleThresholdGenerator extends ChoiceGeneratorBase<Double> implem
   @Override
   public Double getNextChoice () {
     if (count >=0) {
-      return new Double(values[count]);
+      return values[count];
     } else {
-      return new Double(values[0]);
+      return values[0];
     }
   }
 

--- a/src/main/gov/nasa/jpf/vm/choice/FloatChoiceFromList.java
+++ b/src/main/gov/nasa/jpf/vm/choice/FloatChoiceFromList.java
@@ -42,12 +42,12 @@ public class FloatChoiceFromList extends NumberChoiceFromList<Float> implements 
   @Override
   protected Float parseLiteral (String literal, int sign){
     Float val = Float.parseFloat(literal);
-    return new Float( val * sign);
+    return val * sign;
   }
   
   @Override
   protected Float newValue (Number num, int sign){
-    return new Float( num.intValue() * sign);
+    return (float) (num.intValue() * sign);
   }
   
   /**

--- a/src/main/gov/nasa/jpf/vm/choice/IntChoiceFromList.java
+++ b/src/main/gov/nasa/jpf/vm/choice/IntChoiceFromList.java
@@ -50,12 +50,12 @@ public class IntChoiceFromList extends NumberChoiceFromList<Integer> implements 
   @Override
   protected Integer parseLiteral (String literal, int sign){
     int val = Integer.parseInt(literal);
-    return new Integer( val * sign);
+    return val * sign;
   }
   
   @Override
   protected Integer newValue (Number num, int sign){
-    return new Integer( num.intValue() * sign);
+    return num.intValue() * sign;
   }
   
   /**

--- a/src/main/gov/nasa/jpf/vm/choice/IntIntervalGenerator.java
+++ b/src/main/gov/nasa/jpf/vm/choice/IntIntervalGenerator.java
@@ -106,7 +106,7 @@ public class IntIntervalGenerator extends ChoiceGeneratorBase<Integer> implement
   
   @Override
   public Integer getNextChoice () {
-    return new Integer(next);
+    return next;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/choice/LongChoiceFromList.java
+++ b/src/main/gov/nasa/jpf/vm/choice/LongChoiceFromList.java
@@ -41,12 +41,12 @@ public class LongChoiceFromList extends NumberChoiceFromList<Long> implements Lo
   @Override
   protected Long parseLiteral(String literal, int sign) {
     long val = Long.parseLong(literal);
-    return new Long(val * sign);
+    return val * sign;
   }
 
   @Override
   protected Long newValue(Number num, int sign) {
-    return new Long(num.longValue() * sign);
+    return num.longValue() * sign;
   }
 
   /**

--- a/src/main/gov/nasa/jpf/vm/choice/RandomIntIntervalGenerator.java
+++ b/src/main/gov/nasa/jpf/vm/choice/RandomIntIntervalGenerator.java
@@ -111,7 +111,7 @@ public class RandomIntIntervalGenerator extends ChoiceGeneratorBase<Integer> imp
 
   @Override
   public Integer getNextChoice () {
-    return new Integer(next);
+    return next;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/choice/RandomOrderIntCG.java
+++ b/src/main/gov/nasa/jpf/vm/choice/RandomOrderIntCG.java
@@ -57,7 +57,7 @@ public class RandomOrderIntCG extends ChoiceGeneratorBase<Integer> implements In
   
   @Override
   public Integer getNextChoice() {
-    return new Integer(choices[nextIdx]);
+    return choices[nextIdx];
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/choice/RandomOrderLongCG.java
+++ b/src/main/gov/nasa/jpf/vm/choice/RandomOrderLongCG.java
@@ -58,7 +58,7 @@ public class RandomOrderLongCG extends ChoiceGeneratorBase<Long> implements Long
 
   @Override
   public Long getNextChoice() {
-    return new Long(choices[nextIdx]);
+    return choices[nextIdx];
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/choice/TypedObjectChoice.java
+++ b/src/main/gov/nasa/jpf/vm/choice/TypedObjectChoice.java
@@ -115,9 +115,9 @@ public class TypedObjectChoice extends ChoiceGeneratorBase<Integer> implements R
   @Override
   public Integer getNextChoice () {
     if ((count >= 0) && (count < values.length)) {
-      return new Integer(values[count]);
+      return values[count];
     } else {
-      return new Integer(-1);
+      return -1;
     }
   }
   

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_io_RandomAccessFile.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_io_RandomAccessFile.java
@@ -44,7 +44,7 @@ public class JPF_java_io_RandomAccessFile extends NativePeer {
 	// get the mapped object if one exists
 	private static int getMapping(MJIEnv env, int this_ptr) {
 		int fn_ptr = env.getReferenceField(this_ptr,"filename");
-		Object o = File2DataMap.get(new Integer(fn_ptr));
+		Object o = File2DataMap.get(fn_ptr);
 		if (o == null)
 			return this_ptr;
 		return ((Integer)o).intValue();
@@ -54,8 +54,8 @@ public class JPF_java_io_RandomAccessFile extends NativePeer {
   @MJI
 	public void setDataMap____V (MJIEnv env, int this_ptr) {
 		int fn_ptr = env.getReferenceField(this_ptr,"filename");
-		if (!File2DataMap.containsKey(new Integer(fn_ptr))) 
-			File2DataMap.put(new Integer(fn_ptr),new Integer(this_ptr));
+		if (!File2DataMap.containsKey(fn_ptr))
+			File2DataMap.put(fn_ptr, this_ptr);
 	}
 	
   static ClassInfo getDataRepresentationClassInfo (MJIEnv env) {

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_text_Format.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_text_Format.java
@@ -41,7 +41,7 @@ public class JPF_java_text_Format extends NativePeer {
   
   static void putInstance (MJIEnv env, int objref, Format fmt) {
     int id = env.getIntField(objref,  "id");
-    formatters.put(new Integer(id), fmt);
+    formatters.put(id, fmt);
   }
 
   static Format getInstance (MJIEnv env, int objref) {

--- a/src/tests/gov/nasa/jpf/test/java/lang/BoxObjectCacheTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/BoxObjectCacheTest.java
@@ -129,6 +129,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testIntCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Integer i1 = Integer.valueOf( 1);        // should be cached
@@ -142,6 +143,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testCharacterCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Character c1 = Character.valueOf( '?');        // should be cached
@@ -155,6 +157,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testByteCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Byte b1 = Byte.valueOf( (byte)1);        // should be cached
@@ -168,6 +171,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testShortCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Short s1 = Short.valueOf((short)1);        // should be cached
@@ -181,6 +185,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testLongCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Long l1 = Long.valueOf(1);        // should be cached
@@ -194,6 +199,7 @@ public class BoxObjectCacheTest extends TestJPF {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testBooleanCacheBoxObject() throws SecurityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException{
     if (verifyNoPropertyViolation(JPF_ARGS)){
       Boolean b1 = Boolean.valueOf(true);        // should be cached

--- a/src/tests/gov/nasa/jpf/test/java/lang/SystemTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/SystemTest.java
@@ -125,7 +125,7 @@ public class SystemTest extends TestJPF {
   public void testIncompatibleReferencesArrayCopy(){
     if (verifyUnhandledException("java.lang.ArrayStoreException")){
       String[] dst = new String[2];
-      Object[] src = { "one", new Integer(2) };
+      Object[] src = { "one", 2};
 
       System.arraycopy(src,0,dst,0,src.length);
     }

--- a/src/tests/gov/nasa/jpf/test/mc/basic/AttrsTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/AttrsTest.java
@@ -361,6 +361,7 @@ public class AttrsTest extends TestJPF {
     }
   }
   
+  @SuppressWarnings("deprecation")
   @Test public void testInteger() {
     if (verifyNoPropertyViolation()) {
       int v = 42;

--- a/src/tests/gov/nasa/jpf/test/mc/basic/AttrsTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/AttrsTest.java
@@ -391,7 +391,7 @@ public class AttrsTest extends TestJPF {
   @Test public void testObjectAttr(){
 
     if (verifyNoPropertyViolation()){
-      Integer o = new Integer(41);
+      Integer o = 41;
       Verify.setObjectAttribute(o, 42);
 
       boolean b = Verify.getBoolean();

--- a/src/tests/gov/nasa/jpf/test/mc/basic/OOMEInjectorTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/OOMEInjectorTest.java
@@ -29,13 +29,13 @@ public class OOMEInjectorTest extends TestJPF {
   public void testDirectLoc () {
     if (verifyUnhandledException("java.lang.OutOfMemoryError", "+listener=.listener.OOMEInjector",
                                   "+oome.locations=OOMEInjectorTest.java:32")){
-      Object o = new Integer(42);
+      Object o = 42;
     }
   }
   
   
   static int bar(int y){
-    Integer res = new Integer(y);  // this should fail
+    Integer res = y;  // this should fail
     return res;
   }
   

--- a/src/tests/gov/nasa/jpf/test/mc/data/ObjectStreamTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/data/ObjectStreamTest.java
@@ -47,7 +47,7 @@ public class ObjectStreamTest extends TestJPF {
   @Test
   public void testWriteReadInteger() {
     if (!isJPFRun()) {
-      Verify.writeObjectToFile(new Integer(123), osFileName);
+      Verify.writeObjectToFile(123, osFileName);
     }
 
     if (verifyNoPropertyViolation()) {

--- a/src/tests/gov/nasa/jpf/test/vm/basic/ArrayTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/ArrayTest.java
@@ -76,7 +76,7 @@ public class ArrayTest extends TestJPF {
     if (verifyNoPropertyViolation()) {
       try {
         Object x[] = new String[1];
-        x[0] = new Integer(42);
+        x[0] = 42;
       } catch (ArrayStoreException osx) {
         return;
       }
@@ -91,7 +91,7 @@ public class ArrayTest extends TestJPF {
 
       boolean caught = false;
       try {
-        System.arraycopy(new Object[]{new Integer(42)}, 0, new String[2], 0, 1);
+        System.arraycopy(new Object[]{42}, 0, new String[2], 0, 1);
       } catch (ArrayStoreException x) {
         caught = true;
       }
@@ -101,7 +101,7 @@ public class ArrayTest extends TestJPF {
 
       caught = false;
       try {
-        System.arraycopy(new Object[]{new Integer(42)}, 0, new int[2], 0, 1);
+        System.arraycopy(new Object[]{42}, 0, new int[2], 0, 1);
       } catch (ArrayStoreException x) {
         caught = true;
       }

--- a/src/tests/gov/nasa/jpf/test/vm/basic/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/FieldTest.java
@@ -158,8 +158,8 @@ public class FieldTest extends TestFieldBase {
       base_D = _D;
       assert base_D == _D;
 
-      _o = new Integer(42);
-      assert _o.equals(new Integer(42));
+      _o = 42;
+      assert _o.equals(42);
       base_o = _o;
       assert base_o.equals(_o);
     }
@@ -202,8 +202,8 @@ public class FieldTest extends TestFieldBase {
       s_base_D = s_D;
       assert s_base_D == s_D;
 
-      s_o = new Integer(42);
-      assert s_o.equals(new Integer(42));
+      s_o = 42;
+      assert s_o.equals(42);
       s_base_o = s_o;
       assert s_base_o.equals(s_o);
     }

--- a/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
@@ -59,7 +59,7 @@ class TestMethodBase extends TestJPF implements TMI {
     assert l == 424242;
     assert f == 4.2f;
     assert d == 4.242;
-    assert o.equals(new Integer(42));
+    assert o.equals(42);
 
     baseData = 44;
 
@@ -113,7 +113,7 @@ public class MethodTest extends TestMethodBase {
     assert l == 424242;
     assert f == 4.2f;
     assert d == 4.242;
-    assert o.equals(new Integer(42));
+    assert o.equals(42);
 
     data = 43;
 
@@ -146,7 +146,7 @@ public class MethodTest extends TestMethodBase {
   public void testCall() {
     if (verifyNoPropertyViolation()) {
       MethodTest o = new MethodTest();
-      assert o.foo(true, (byte) 4, '?', (short) 42, 4242, 424242, 4.2f, 4.242, new Integer(42)) == 4.242;
+      assert o.foo(true, (byte) 4, '?', (short) 42, 4242, 424242, 4.2f, 4.242, 42) == 4.242;
       assert o.data == 43;
     }
   }
@@ -155,7 +155,7 @@ public class MethodTest extends TestMethodBase {
   public void testInheritedCall() {
     if (verifyNoPropertyViolation()) {
       MethodTest o = new MethodTest();
-      assert o.baz(true, (byte) 4, '?', (short) 42, 4242, 424242, 4.2f, 4.242, new Integer(42));
+      assert o.baz(true, (byte) 4, '?', (short) 42, 4242, 424242, 4.2f, 4.242, 42);
       assert o.baseData == 44;
     }
   }

--- a/src/tests/gov/nasa/jpf/test/vm/reflection/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/reflection/FieldTest.java
@@ -28,7 +28,7 @@ public class FieldTest extends TestJPF {
   int instInt = 42;
   double instDouble = 42.0;
   double primField = 42.0;
-  Object refField = new Integer(42);
+  Object refField = 42;
   int[] arrayField = new int[]{42};
 
   static int statInt = 43;
@@ -102,7 +102,7 @@ public class FieldTest extends TestJPF {
         double d = ((Double) f.get(this)).doubleValue();
         assert d == 42.0;
 
-        f.set(this, new Double(43.0));
+        f.set(this, 43.0);
         assert primField == 43.0;
 
       } catch (Throwable t) {
@@ -122,7 +122,7 @@ public class FieldTest extends TestJPF {
         Object o = f.get(this);
         assert o == refField;
 
-        Object ob = new Double(43.0);
+        Object ob = 43.0;
         f.set(this, ob);
         assert ob == refField;
 

--- a/src/tests/gov/nasa/jpf/test/vm/reflection/MethodTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/reflection/MethodTest.java
@@ -84,7 +84,7 @@ public class MethodTest extends TestJPF {
         Class<?> cls = o.getClass();
         Method m = cls.getMethod("foo", int.class, double.class, String.class);
 
-        Object res = m.invoke(o, new Integer(3), new Double(3.33), "Blah");
+        Object res = m.invoke(o, 3, 3.33, "Blah");
         double d = ((Double) res).doubleValue();
         System.out.println("foo returned " + d);
 
@@ -113,7 +113,7 @@ public class MethodTest extends TestJPF {
         Class<?> cls = o.getClass();
         Method m = cls.getMethod("harr", int.class);
 
-        Object res = m.invoke(null, new Integer(41));
+        Object res = m.invoke(null, 41);
         int r = (Integer)res;
         System.out.println("harr returned " + r);
 

--- a/src/tests/gov/nasa/jpf/util/ObjectListTest.java
+++ b/src/tests/gov/nasa/jpf/util/ObjectListTest.java
@@ -36,7 +36,7 @@ public class ObjectListTest extends TestJPF {
     assertTrue( ObjectList.size(attr) == 1);
     assertTrue( attr != null && attr.equals("one"));
     
-    attr = ObjectList.add(attr, new Integer(2));
+    attr = ObjectList.add(attr, 2);
     assertTrue( ObjectList.size(attr) == 2);
     assertTrue( attr != null && !(attr instanceof Integer));
   }
@@ -44,7 +44,7 @@ public class ObjectListTest extends TestJPF {
   
   @Test
   public void testListIteration() {
-    Object[] v = { new Integer(2), "one" };
+    Object[] v = {2, "one" };
     
     for (Object a: ObjectList.iterator(attr)){
       fail("list should be empty");
@@ -62,7 +62,7 @@ public class ObjectListTest extends TestJPF {
     }
 
     attr = ObjectList.add(attr, "three");
-    attr = ObjectList.add(attr, new Integer(4));
+    attr = ObjectList.add(attr, 4);
     
     int i=0;
     for (Integer a = ObjectList.getFirst(attr, Integer.class); a!=null; a = ObjectList.getNext(attr, Integer.class, a)){
@@ -157,12 +157,12 @@ public class ObjectListTest extends TestJPF {
     String one = "one";
     attr = ObjectList.add(attr, one);
     
-    Integer i1 = new Integer(1);
+    Integer i1 = 1;
     attr = ObjectList.replace(attr, one, i1);
     assertTrue(attr == i1);
     
     String two = "two";
-    Integer i2 = new Integer(2);
+    Integer i2 = 2;
     attr = ObjectList.add(attr, two);
     attr = ObjectList.replace(attr, two, i2);
     Integer o = ObjectList.getFirst(attr, Integer.class);

--- a/src/tests/gov/nasa/jpf/util/SparseClusterArrayTest.java
+++ b/src/tests/gov/nasa/jpf/util/SparseClusterArrayTest.java
@@ -59,14 +59,14 @@ public class SparseClusterArrayTest extends TestJPF {
     int ref;
 
     ref = (1 << S1) | 42;
-    arr.set(ref, (v = new Integer(ref)));
+    arr.set(ref, (v = ref));
 
     Object o = arr.get(ref);
     System.out.println(o);
     assert o.equals(v);
 
     ref = (2 << S1);
-    arr.set(ref, new Integer(ref));
+    arr.set(ref, ref);
 
     System.out.println("cardinality = " + arr.cardinality());
     assert arr.cardinality() == 2;
@@ -78,7 +78,7 @@ public class SparseClusterArrayTest extends TestJPF {
 
   @Test
   public void testNextNull () {
-    Object e = new Integer(42);
+    Object e = 42;
     SparseClusterArray<Object> arr = new SparseClusterArray<Object>();
     int k;
     int limit = 10000000;
@@ -173,9 +173,9 @@ public class SparseClusterArrayTest extends TestJPF {
   public void testClone() {
     SparseClusterArray<Integer> arr = new SparseClusterArray<Integer>();
 
-    arr.set(0, new Integer(0));
-    arr.set(42, new Integer(42));
-    arr.set(6762, new Integer(6762));
+    arr.set(0, 0);
+    arr.set(42, 42);
+    arr.set(6762, 6762);
     arr.set(6762, null);
 
     Cloner<Integer> cloner = new Cloner<Integer>() {
@@ -199,14 +199,14 @@ public class SparseClusterArrayTest extends TestJPF {
   public void testSnapshot() {
     SparseClusterArray<Integer> arr = new SparseClusterArray<Integer>();
 
-    arr.set(0, new Integer(0));
-    arr.set(42, new Integer(42));
-    arr.set(4095, new Integer(4095));
-    arr.set(4096, new Integer(4096));
-    arr.set(7777, new Integer(7777));
-    arr.set(67620, new Integer(67620));
+    arr.set(0, 0);
+    arr.set(42, 42);
+    arr.set(4095, 4095);
+    arr.set(4096, 4096);
+    arr.set(7777, 7777);
+    arr.set(67620, 67620);
     arr.set(67620, null);
-    arr.set(7162827, new Integer(7162827));
+    arr.set(7162827, 7162827);
 
     Transformer<Integer,String> i2s = new Transformer<Integer,String>() {
       @Override
@@ -218,7 +218,7 @@ public class SparseClusterArrayTest extends TestJPF {
     Transformer<String,Integer> s2i = new Transformer<String,Integer>() {
       @Override
 	public Integer transform (String s) {
-        return new Integer( Integer.parseInt(s));
+        return Integer.parseInt(s);
       }
     };
 
@@ -230,8 +230,8 @@ public class SparseClusterArrayTest extends TestJPF {
     }
 
     arr.set(42,null);
-    arr.set(87, new Integer(87));
-    arr.set(7162827, new Integer(-1));
+    arr.set(87, 87);
+    arr.set(7162827, -1);
 
     arr.restore(snap, s2i);
     for (Integer i : arr) {
@@ -251,17 +251,17 @@ public class SparseClusterArrayTest extends TestJPF {
   public void testChanges() {
     SparseClusterArray<Integer> arr = new SparseClusterArray<Integer>();
 
-    arr.set(42, new Integer(42));
-    arr.set(6276, new Integer(6276));
+    arr.set(42, 42);
+    arr.set(6276, 6276);
 
     arr.trackChanges();
 
-    arr.set(0, new Integer(0));
-    arr.set(42, new Integer(-1));
-    arr.set(4095, new Integer(4095));
-    arr.set(4096, new Integer(4096));
-    arr.set(7777, new Integer(7777));
-    arr.set(7162827, new Integer(7162827));
+    arr.set(0, 0);
+    arr.set(42, -1);
+    arr.set(4095, 4095);
+    arr.set(4096, 4096);
+    arr.set(7777, 7777);
+    arr.set(7162827, 7162827);
 
     Entry<Integer> changes = arr.getChanges();
     arr.revertChanges(changes);

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -112,7 +112,7 @@ public class LambdaTest extends TestJPF{
     }
   }
   
-  static Integer io = new Integer(20);
+  static Integer io = 20;
   
   @Test
   public void testClosure() {


### PR DESCRIPTION
This fixes some of the deprecation warnings as stated in #47 (due to the use of the Number constructor on the primitive types) by removing unnecessary explicit manual boxing and by use of  `@SuppressWarnings("deprecation")` annotation.

Fixes: #47