### PR TITLE
Remove countStackFrames() in StackDepthCheckerTest#testInfiniteRecursion

### DIFF
--- a/src/tests/gov/nasa/jpf/test/mc/basic/StackDepthCheckerTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/StackDepthCheckerTest.java
@@ -35,19 +35,14 @@ public class StackDepthCheckerTest extends TestJPF {
     System.out.println(n);
     
     foo();
-    
-    n--; // not that we ever get here
-    System.out.print("exited foo() at level ");
-    System.out.println(n);
+
+    // this function never returns
   }
   
   @Test 
-  @SuppressWarnings("deprecation")
   public void testInfiniteRecursion (){
     if (verifyUnhandledException("java.lang.StackOverflowError", 
         "+listener=.listener.StackDepthChecker", "+sdc.max_stack_depth=42")){
-      Thread t = Thread.currentThread();
-      n = t.countStackFrames(); // it's deprecated, but we just want to make the printout more readable
       foo();
     }
   }


### PR DESCRIPTION
Seeting the stack frame depth (n) in here is also not very important. So removed.

Fixes: #62