### PR TITLE
Replaces all the occurrences of clazz.newInstance()

### DIFF
--- a/src/main/gov/nasa/jpf/listener/PathOutputMonitor.java
+++ b/src/main/gov/nasa/jpf/listener/PathOutputMonitor.java
@@ -239,7 +239,7 @@ public class PathOutputMonitor extends PropertyListenerAdapter {
 
   PathOutputSpec createPathOutputSpec() {
     try {
-      return psClass.newInstance();
+      return psClass.getDeclaredConstructor().newInstance();
     } catch (Throwable t) {
       log.severe("cannot instantiate PathoutputSpec class: " + t.getMessage());
       return null;

--- a/src/main/gov/nasa/jpf/tool/PrintEvents.java
+++ b/src/main/gov/nasa/jpf/tool/PrintEvents.java
@@ -24,6 +24,7 @@ import gov.nasa.jpf.util.FileUtils;
 import gov.nasa.jpf.util.JPFSiteUtils;
 import gov.nasa.jpf.util.event.EventTree;
 
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * very simple tool to print .util.script.EventTrees
@@ -102,7 +103,7 @@ public class PrintEvents {
 
     try {     
       Class<EventTree> cls = (Class<EventTree>)cl.loadClass(clsName);
-      EventTree et = cls.newInstance();
+      EventTree et = cls.getDeclaredConstructor().newInstance();
       
       if (printTree){
         System.out.println("---------------- event tree of " + clsName);
@@ -116,11 +117,15 @@ public class PrintEvents {
     } catch (ClassNotFoundException cnfx){
       System.err.println("class not found: " + clsName);
     } catch (NoClassDefFoundError ncdf){
-      System.err.println("class does not load: " + ncdf.getMessage());      
+      System.err.println("class does not load: " + ncdf.getMessage());
     } catch (InstantiationException ex) {
       System.err.println("cannot instantiate: " + ex.getMessage());      
     } catch (IllegalAccessException ex) {
-      System.err.println("cannot instantiate: " + ex.getMessage());      
+      System.err.println("constructor is inaccessible: " + ex.getMessage());
+    } catch (NoSuchMethodException e) {
+      System.err.println("cannot find constructor: " + e.getMessage());
+    } catch (InvocationTargetException e) {
+      System.err.println("constructor invocation throws an exception: " + e.getMessage());
     }
   }
 }

--- a/src/main/gov/nasa/jpf/util/ObjectConverter.java
+++ b/src/main/gov/nasa/jpf/util/ObjectConverter.java
@@ -244,7 +244,7 @@ public class ObjectConverter {
       String typeName = ei.getType();
       Class clazz = ClassLoader.getSystemClassLoader().loadClass(typeName);
 
-      Object javaObject = clazz.newInstance();
+      Object javaObject = clazz.getDeclaredConstructor().newInstance();
       ClassInfo ci = ei.getClassInfo();
       while (ci != null) {
 

--- a/src/main/gov/nasa/jpf/util/test/TestJPF.java
+++ b/src/main/gov/nasa/jpf/util/test/TestJPF.java
@@ -543,7 +543,7 @@ public abstract class TestJPF implements JPFShell  {
         testMethodName = testMethod.getName();
         String result = testMethodName;
         try {
-          Object testObject = testCls.newInstance();
+          Object testObject = testCls.getDeclaredConstructor().newInstance();
 
           nTests++;
           reportTestStart( testMethodName);
@@ -564,7 +564,7 @@ public abstract class TestJPF implements JPFShell  {
             invoke( cleanupMethod, testObject);
           }
 
-        } catch (InvocationTargetException x) {
+        } catch (InvocationTargetException | NoSuchMethodException x) {
           Throwable cause = x.getCause();
           cause.printStackTrace();
           if (cause instanceof AssertionError) {
@@ -640,7 +640,7 @@ public abstract class TestJPF implements JPFShell  {
     String testMthName = getProperty("target.test_method");
     
     Class<?> testCls = Class.forName(testClsName);
-    Object target = testCls.newInstance();
+    Object target = testCls.getDeclaredConstructor().newInstance();
     
     Method method = testCls.getMethod(testMthName);
 

--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -30,6 +30,7 @@ import gov.nasa.jpf.util.OATHash;
 import gov.nasa.jpf.util.Source;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -399,17 +400,19 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
         for (String clsName : attrTypes){
           try {
             Class<?> attrCls = loader.loadClass(clsName);
-            Object attr = attrCls.newInstance(); // needs to have a default ctor
+            Object attr = attrCls.getDeclaredConstructor().newInstance(); // needs to have a default ctor
             infoObj.addAttr(attr);
             
           } catch (ClassNotFoundException cnfx){
             logger.warning("attribute class not found: " + clsName);
-            
+          } catch (NoSuchMethodException e) {
+            logger.warning("attribute class has no public default ctor: " + clsName);
           } catch (IllegalAccessException iax){
-            logger.warning("attribute class has no public default ctor: " + clsName);            
-            
+            logger.warning("attribute class's public default ctor is inaccessible: " + clsName);
           } catch (InstantiationException ix){
-            logger.warning("attribute class has no default ctor: " + clsName);            
+            logger.warning("underlying constructor is an abstract class: " + clsName);
+          } catch (InvocationTargetException e) {
+            logger.warning("attribute class's default ctor throws an exception: " + clsName);
           }
         }
       }

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -150,10 +150,10 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
   }
   
   @Test 
-  public void testNewInstance () throws InstantiationException, IllegalAccessException {
+  public void testNewInstance () throws ReflectiveOperationException {
     if (verifyNoPropertyViolation()) {
       Class<?> clazz = ClassTest.class;
-      ClassTest o = (ClassTest) clazz.newInstance();
+      ClassTest o = (ClassTest) clazz.getDeclaredConstructor().newInstance();
       
       System.out.println("new instance: " + o);
       
@@ -169,10 +169,10 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
   }
   
   @Test 
-  public void testNewInstanceFailAccess () throws IllegalAccessException, InstantiationException {
+  public void testNewInstanceFailAccess () throws ReflectiveOperationException {
     if (verifyUnhandledException("java.lang.IllegalAccessException")){
       Class<?> clazz = InAccessible.class;
-      clazz.newInstance();
+      clazz.getDeclaredConstructor().newInstance();
     }
   }
   
@@ -180,10 +180,10 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
   }
     
   @Test 
-  public void testNewInstanceFailAbstract () throws IllegalAccessException, InstantiationException {
+  public void testNewInstanceFailAbstract () throws ReflectiveOperationException {
     if (verifyUnhandledException("java.lang.InstantiationException")){
       Class<?> clazz = AbstractClass.class;
-      clazz.newInstance();
+      clazz.getDeclaredConstructor().newInstance();
     }
   }
   

--- a/src/tests/gov/nasa/jpf/test/vm/basic/RecursiveClinitTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/RecursiveClinitTest.java
@@ -66,7 +66,7 @@ public class RecursiveClinitTest extends TestJPF {
     if (verifyNoPropertyViolation()) {
       System.out.println("main now calling Derived.class.newInstance()");
       try {
-        Derived.class.newInstance();
+        Derived.class.getDeclaredConstructor().newInstance();
       } catch (Throwable t) {
         fail("instantiation failed with " + t);
       }


### PR DESCRIPTION
Replaces all the occurrences of

    clazz.newInstance()

in jpf-core with

    clazz.getDeclaredConstructor().newInstance()

From
http://cr.openjdk.java.net/~iris/se/10/latestSpec/api/java/lang/Class.html#newInstance()

Class.newInstance() method propagates any exception thrown by the
nullary constructor, including a checked exception. Use of this method
effectively bypasses the compile-time exception checking that would
otherwise be performed by the compiler. The Constructor.newInstance
method avoids this problem by wrapping any exception thrown by the
constructor in a (checked) InvocationTargetException.

Fixes: #61