### PR TITLE
Refactor a reference to sun.misc.Unsafe

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -107,6 +107,9 @@
     <javac srcdir="src/peers" destdir="build/peers" includeantruntime="false"
            debug="${debug}" deprecation="${deprecation}" classpathref="lib.path">
       <compilerarg value="-Xlint:all,-serial"/>
+
+      <compilerarg value="--add-exports"/>
+      <compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED"/>
      </javac>
   </target>
   

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_util_Random.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_util_Random.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Field;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
-import sun.misc.Unsafe;
+import jdk.internal.misc.Unsafe;
 
 /**
  * MJI NativePeer class for java.util.Random library abstraction


### PR DESCRIPTION
This refactors sun.misc.Unsafe to jdk.internal.misc.Unsafe in
JPF_java_util_Random.java

So to fix the compiler warning:

    [javac] /home/travis/build/javapathfinder/jpf-core/src/peers/gov/nasa/jpf/vm/JPF_java_util_Random.java:99:
     warning: Unsafe is internal proprietary API and may be removed in a future release

However package jdk.internal.misc is declared in module java.base, which does
not export it to the unnamed module (src/peers)

So following compiler argument is neceesary to be added into javac ant
target of src/peers

    <compilerarg value="--add-exports"/>
    <compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED"/>

to prevent the error:

    [javac] /home/gayan/git/javapathfinder/jpf-core/src/peers/gov/nasa/jpf/vm/JPF_java_util_Random.java:32:
               error: package jdk.internal.misc is not visible
    [javac] import jdk.internal.misc.Unsafe;
    [javac]                    ^
    [javac]   (package jdk.internal.misc is declared in module java.base, which does not export it to the unnamed module)

Fixes: #68