### PR TITLE
 Use valueOf instead of Double(double)

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/text/DecimalFormatTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/text/DecimalFormatTest.java
@@ -40,7 +40,7 @@ public class DecimalFormatTest extends TestJPF {
     if (verifyNoPropertyViolation()) {
       StringBuffer sb = new StringBuffer();
       DecimalFormat dFormat = new DecimalFormat();
-      sb = dFormat.format(new Double(42), sb, new FieldPosition(0));
+      sb = dFormat.format(Double.valueOf(42), sb, new FieldPosition(0));
       String output = sb.toString();
       try {
         double d = Double.parseDouble(output);


### PR DESCRIPTION
Double (double) is deprecated. It is suggested that we use the static factory #valueOf(double), as it is likely to yield significantly better space and time performance.

This is a fixup for issue: #47
This is a follow-up to the PR: #59