### PR TITLE
Suppress warning ChoiceGeneratorBase() has been deprecated

### DIFF
--- a/src/main/gov/nasa/jpf/vm/ChoiceGeneratorBase.java
+++ b/src/main/gov/nasa/jpf/vm/ChoiceGeneratorBase.java
@@ -100,7 +100,7 @@ public abstract class ChoiceGeneratorBase<T> implements ChoiceGenerator<T> {
    *  don't use this since it is not safe for cascaded ChoiceGenerators
    * (we need the 'id' to be as context specific as possible)
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   protected ChoiceGeneratorBase() {
     id = "?";
   }

--- a/src/main/gov/nasa/jpf/vm/choice/PermutationCG.java
+++ b/src/main/gov/nasa/jpf/vm/choice/PermutationCG.java
@@ -32,6 +32,8 @@ public class PermutationCG extends ChoiceGeneratorBase<int[]>{
   protected PermutationGenerator pg;
   protected int[] permutation;
   
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("removal")
   public PermutationCG (PermutationGenerator pg){
     this.pg = pg;
   }


### PR DESCRIPTION
Both constructors PermutationCG#PermutationCG(PermutationGenerator), ChoiceGeneratorBase#ChoiceGeneratorBase() is marked for removal. PermutationCG is annotated with @SuppressWarnings("removal") to suppress the warning:

    [javac] src/main/gov/nasa/jpf/vm/choice/PermutationCG.java:35:
      warning: [deprecation] ChoiceGeneratorBase() in ChoiceGeneratorBase has been deprecated
    [javac]   public PermutationCG (PermutationGenerator pg){
    [javac]                                                 ^

Fixes: #72