### PR TITLE
Override hashCode where equals is overridden

### DIFF
--- a/src/tests/TypeNameTest.java
+++ b/src/tests/TypeNameTest.java
@@ -46,6 +46,11 @@ class B {
   }
 
   @Override
+  public int hashCode() {
+    return Integer.hashCode(data);
+  }
+
+  @Override
   public String toString() {
     return "B {data=" + data + "}";
   }

--- a/src/tests/gov/nasa/jpf/test/mc/data/CGCreatorFactoryTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/data/CGCreatorFactoryTest.java
@@ -56,6 +56,10 @@ static class TestBoolCGCreator implements CGCreator {
       return this.b == other.b;
     }
 
+    @Override
+    public int hashCode() {
+        return Boolean.hashCode(b);
+    }
   }
 
   @Test

--- a/src/tests/gov/nasa/jpf/test/mc/data/JSONTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/data/JSONTest.java
@@ -23,6 +23,9 @@ import gov.nasa.jpf.vm.Verify;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 
 /**
  * JPF regression test for JSON test object creation
@@ -350,6 +353,11 @@ public class JSONTest extends TestJPF {
       Bool bool = (Bool) o;
       return this.b == bool.b;
     }
+
+    @Override
+    public int hashCode() {
+      return Boolean.hashCode(b);
+    }
   }
 
   static void checkValue(Object[] expected, Object curVal) {
@@ -398,6 +406,11 @@ public class JSONTest extends TestJPF {
       ByteShortIntLong bs = (ByteShortIntLong) o;
 
       return bs.b == b && bs.s == s && bs.i == i && bs.l == l;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(b, s, i, l);
     }
   }
 
@@ -457,6 +470,11 @@ public class JSONTest extends TestJPF {
 
       return outer.inner.i == this.inner.i;
     }
+
+    @Override
+    public int hashCode() {
+      return Integer.hashCode(inner.i);
+    }
   }
 
   @Test
@@ -498,6 +516,11 @@ public class JSONTest extends TestJPF {
       }
       return true;
     }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(arr);
+    }
   }
 
   @Test
@@ -528,6 +551,11 @@ public class JSONTest extends TestJPF {
     public boolean equals(Object obj) {
       BoxedInteger bic = (BoxedInteger) obj;
       return this.bi.equals(bic.bi);
+    }
+
+    @Override
+    public int hashCode() {
+      return bi.hashCode();
     }
   }
 
@@ -564,6 +592,11 @@ public class JSONTest extends TestJPF {
       double diff = 0.001;
 
       return Math.abs(d1 - d2) <= diff;
+    }
+
+    @Override
+    public int hashCode() {
+      return Double.hashCode(d);
     }
   }
 

--- a/src/tests/gov/nasa/jpf/util/SortedArrayObjectSetTest.java
+++ b/src/tests/gov/nasa/jpf/util/SortedArrayObjectSetTest.java
@@ -21,6 +21,8 @@ package gov.nasa.jpf.util;
 import gov.nasa.jpf.util.test.TestJPF;
 import org.junit.Test;
 
+import java.util.Objects;
+
 
 /**
  * regression test for SortedArrayObjectSet
@@ -58,6 +60,11 @@ public class SortedArrayObjectSetTest extends TestJPF {
       }
       
       return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, x);
     }
   }
   


### PR DESCRIPTION
If two objects are equal according to the equals(Object), then calling
the hashCode method on each of the two objects must produce the same
integer result.

However we have classes in src/tests that overrides equals(Object)
without overriding the hashCode method. This overrides the missing
hashCode methods.

Fixes: #85