### PR TITLE
Annotate FinalizerThreadTest.Finalize#finalize with @SuppressW…("deprecation")

### DIFF
--- a/src/tests/gov/nasa/jpf/test/mc/threads/FinalizerThreadTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/threads/FinalizerThreadTest.java
@@ -37,6 +37,7 @@ public class FinalizerThreadTest extends TestJPF {
     }
     
     @Override
+    @SuppressWarnings("deprecation")
     protected void finalize() throws Throwable {
       System.out.println("finalizer executing... ");
       throw new Exception();


### PR DESCRIPTION
java.lang.Object#finalize is deprecated since Java 9.
`gov.nasa.jpf.test.mc.threads.FinalizerThreadTest.Finalize#finalize` is
not removed to stay compatible with (rare) programs using finalizers.

Fixes: #88