### PR TITLE
Add new auxliary class CompoundEnumeration to ClassLoader.java

### DIFF
--- a/src/classes/modules/java.base/java/lang/ClassLoader.java
+++ b/src/classes/modules/java.base/java/lang/ClassLoader.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
 import java.util.Enumeration;
+import java.util.NoSuchElementException;
 import java.util.Vector;
 
 /**
@@ -251,5 +252,38 @@ public abstract class ClassLoader {
                                   String implVendor, URL sealBase) 
                                       throws IllegalArgumentException {
     throw new UnsupportedOperationException();
+  }
+
+  /*
+   * A utility class that will enumerate over an array of enumerations.
+   */
+  final class CompoundEnumeration<E> implements Enumeration<E> {
+    private final Enumeration<E>[] enums;
+    private int index;
+
+    public CompoundEnumeration(Enumeration<E>[] enums) {
+      this.enums = enums;
+    }
+
+    private boolean next() {
+      while (index < enums.length) {
+        if (enums[index] != null && enums[index].hasMoreElements()) {
+          return true;
+        }
+        index++;
+      }
+      return false;
+    }
+
+    public boolean hasMoreElements() {
+      return next();
+    }
+
+    public E nextElement() {
+      if (!next()) {
+        throw new NoSuchElementException();
+      }
+      return enums[index].nextElement();
+    }
   }
 }


### PR DESCRIPTION
Our java.lang.ClassLoader model class references
java.lang.CompoundEnumeration which is an auxilary class declared within
the java standard class java/lang/ClassLoader.java

This includes CompoundEnumeration class within our model class itself,
so to prevent our ClassLoader model class from referencing an auxilary
class from outside its own source file.

This fixes:
    warning: auxiliary class CompoundEnumeration in ClassLoader.java should
             not be accessed from outside its own source file

Fixes: #90