### PR TITLE
Update JVMClassFileContainer#getClassURL to comply with Module System

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -200,9 +200,7 @@
     <copy file=".version" todir="build/main/gov/nasa/jpf" failonerror="false"/>
 
     <jar jarfile="build/jpf-classes.jar">
-      <fileset dir="build/classes/java.base"/>
-      <fileset dir="build/classes/java.logging"/>
-
+      <fileset dir="build/classes"/>
       <fileset dir="build/annotations"/>
 
       <fileset dir="build/main">

--- a/src/main/gov/nasa/jpf/jvm/DirClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/jvm/DirClassFileContainer.java
@@ -50,8 +50,8 @@ public class DirClassFileContainer extends JVMClassFileContainer {
 
   @Override
   public ClassFileMatch getMatch(String clsName) throws ClassParseException {
-    String pn = clsName.replace('.', File.separatorChar) + ".class";
-    File f = new File(dir, pn);
+    String classEntryURL = getClassEntryURL(clsName);
+    File f = new File(dir, classEntryURL);
 
     if (f.isFile()) {
       FileInputStream fis = null;

--- a/src/main/gov/nasa/jpf/jvm/JVMClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassFileContainer.java
@@ -18,11 +18,14 @@
 
 package gov.nasa.jpf.jvm;
 
+import gov.nasa.jpf.JPFException;
 import gov.nasa.jpf.vm.AnnotationInfo;
 import gov.nasa.jpf.vm.ClassFileContainer;
 import gov.nasa.jpf.vm.ClassFileMatch;
 import gov.nasa.jpf.vm.ClassLoaderInfo;
 import gov.nasa.jpf.vm.ClassParseException;
+
+import java.io.File;
 
 /**
  * ClassFileContainer that holds Java classfiles
@@ -70,10 +73,44 @@ public abstract class JVMClassFileContainer extends ClassFileContainer {
   protected JVMClassFileContainer (String name, String url) {
     super(name, url);
   }
-  
+
+  /**
+   * @return the path to .class file including the source path of the container
+   * eg:-
+   *     jar:file:/path/to/jpf-classes.jar!/java.base/java/lang/Object.class
+   *
+   *     /path/to/build/tests/TypeNameTest.class
+   */
   @Override
   public String getClassURL (String typeName){
-    return getURL() + typeName.replace('.', '/') + ".class";
+    return getURL() + getClassEntryURL(typeName);
+  }
+
+  /**
+   * @param typeName in the format java.lang.Object
+   * @return Returns a path to .class file including the module name
+   * in a format similar to java.base/java/lang/Object.class
+   *
+   * If the module for the typeName is an unnamed module, returns a path in a format similar to
+   * java/lang/Object.class
+   */
+  static String getClassEntryURL(String typeName) {
+    String moduleName = getModuleName(typeName);
+    if (moduleName == null) {
+      return typeName.replace('.', File.separatorChar) + ".class";
+    }
+    return moduleName + File.separator + typeName.replace('.', File.separatorChar) + ".class";
+  }
+
+  /**
+   * @return the module name for the given typeName or null if the module is an unnamed module
+   */
+  static String getModuleName(String typeName) {
+    try {
+      return Class.forName(typeName.split("\\$")[0]).getModule().getName();
+    } catch (ClassNotFoundException e) {
+      throw new JPFException("Class for typename " + typeName + " not found", e);
+    }
   }
 
 }

--- a/src/main/gov/nasa/jpf/jvm/JarClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/jvm/JarClassFileContainer.java
@@ -114,13 +114,13 @@ public class JarClassFileContainer extends JVMClassFileContainer {
     
   @Override
   public ClassFileMatch getMatch(String clsName) throws ClassParseException {
-    String pn = clsName.replace('.', '/') + ".class";
+    String classEntryURL = getClassEntryURL(clsName);
     
     if (pathPrefix != null){
-      pn = pathPrefix + pn;
+      classEntryURL = pathPrefix + classEntryURL;
     }
     
-    JarEntry e = jar.getJarEntry(pn);
+    JarEntry e = jar.getJarEntry(classEntryURL);
 
     if (e != null) {
       InputStream is = null;

--- a/src/main/gov/nasa/jpf/vm/ClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/vm/ClassFileContainer.java
@@ -35,6 +35,13 @@ public abstract class ClassFileContainer {
     return name;
   }
 
+  /**
+   * @return the path of the container
+   * eg :-
+   *     /path/to/root/dir/that/contains/class/files
+   *
+   *     jar:file:/path/to/jpf-classes.jar!/
+   */
   public String getURL() {
     return url;
   }


### PR DESCRIPTION
This updates JVMClassFileContainer#getClassURL to comply with the URI structure used in the new Java Module System.

This is related to the issue #50 which is about JPF failing to load model classes from jpf-classes.jar due to different URI structure of the .class files being introuduced in Java Module System. The previous workaround introudced by the PR #51 is specifically for the jpf-classes.jar. JPF will still fail to locate classes from the other jar files.

Thus this reverts it. And make a implementation changes to JVMClassFileContainer#getClassURL which is JPF's universal container for holding Java class files. 