### PR TITLE
Add a new constructor BootstrapMethodInfo(enclosingClass, cpArgs)

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -88,8 +88,12 @@ public class JVMClassInfo extends ClassInfo {
     }
     
     @Override
-    public void setBootstrapMethod (ClassFile cf, Object tag, int idx, int refKind, String cls, String mth, String descriptor, int[] cpArgs) {    
-   
+    public void setBootstrapMethod (ClassFile cf, Object tag, int idx, int refKind, String cls, String mth, String descriptor, int[] cpArgs) {
+      if (cls.equals("java/lang/invoke/StringConcatFactory")) {
+        bootstrapMethods[idx] = new BootstrapMethodInfo(JVMClassInfo.this, cpArgs);
+        return;
+      }
+
       int lambdaRefKind = cf.mhRefTypeAt(cpArgs[1]);
       
       int mrefIdx = cf.mhMethodRefIndexAt(cpArgs[1]);

--- a/src/main/gov/nasa/jpf/vm/BootstrapMethodInfo.java
+++ b/src/main/gov/nasa/jpf/vm/BootstrapMethodInfo.java
@@ -44,7 +44,16 @@ public class BootstrapMethodInfo {
     this.lambdaBody = lambdaBody;
     this.samDescriptor = samDescriptor;
   }
-  
+
+  /**
+   * Constructor for constructing {@link BootstrapMethodInfo} for bootstrap methods
+   * with arbitrary number of bootstrap method arguments
+   */
+  public BootstrapMethodInfo(ClassInfo enclosingClass, int[] cpArgs) {
+    this.enclosingClass = enclosingClass;
+      // TODO: find a way to parse lambdaBody, samDescriptor etc
+  }
+
   @Override
   public String toString() {
     return "BootstrapMethodInfo[" + enclosingClass.getName() + "." + lambdaBody.getBaseName() + 

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -301,4 +301,13 @@ public class StringTest extends TestJPF {
       assertTrue( s.contentEquals(sb));
     }
   }
+
+	@Test
+	public void testConcat() {
+		if (verifyNoPropertyViolation()) {
+			String str = "Hello, ";
+			String out = str + "World!";
+			assert out.equals("Hello, World!");
+		}
+	}
 }


### PR DESCRIPTION
JVMClassInfo.Initializer#setBootstrapMethod method assumes to have a bootstrap method with a structure similar to the following (which have 3 bootstrap method arguments)
```
BootstrapMethods:
  0: #83 REF_invokeStatic java/lang/invoke/LambdaMetafactory.metafactory:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;
    Method arguments:
      #84 (Ljava/lang/Object;)Ljava/lang/Object;
      #85 REF_invokeInterface java/lang/annotation/Annotation.annotationType:()Ljava/lang/Class;
      #86 (Ljava/lang/annotation/Annotation;)Ljava/lang/Class;
```
In case JPF encounters a bootstrap method with arbitrary number of arguments such as the StringConcatFactory.makeConcatWithConstants which have only one bootstrap method argument JVMClassInfo.Initializer#setBootstrapMethod throws an ArrayIndexOutOfBoundsException exception:
```
[junit] java.lang.ArrayIndexOutOfBoundsException: 1
[junit] 	at gov.nasa.jpf.jvm.JVMClassInfo$Initializer.setBootstrapMethod(JVMClassInfo.java:93)
[junit] 	at gov.nasa.jpf.jvm.ClassFile.setBootstrapMethod(ClassFile.java:659)
[junit] 	at gov.nasa.jpf.jvm.ClassFile.parseBootstrapMethodAttr(ClassFile.java:1422)
[junit] 	at gov.nasa.jpf.jvm.JVMClassInfo$Initializer.setClassAttribute(JVMClassInfo.java:80)
[junit] 	at gov.nasa.jpf.jvm.ClassFile.setClassAttribute(ClassFile.java:636)
[junit] 	at gov.nasa.jpf.jvm.ClassFile.parseClassAttributes(ClassFile.java:1306)
[junit] 	at gov.nasa.jpf.jvm.ClassFile.parse(ClassFile.java:875)
[junit] 	at gov.nasa.jpf.jvm.JVMClassInfo$Initializer.<init>(JVMClassInfo.java:48)
```
This prevents the above exception from being thrown, by adding a new constructor BootstrapMethodInfo#BootstrapMethodInfo(enclosingClass, cpArgs) for handling bootstrap methods with arbitrary number of bootstrap method arguments, without evaluating cpArgs in JVMClassInfo.Initializer#setBootstrapMethod.

Fixes: #53