### PR TITLE
Add gov.nasa.jpf.jvm.JRTClassFileContainer

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JRTClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/jvm/JRTClassFileContainer.java
@@ -1,0 +1,33 @@
+package gov.nasa.jpf.jvm;
+
+import gov.nasa.jpf.vm.ClassFileMatch;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+
+/**
+ * ClassFileContainer to hold classes from the run-time image
+ * Uses the new URL scheme, jrt, to references the classes stored in the run-time image
+ * jrt:/ refers to the root path of the container where all class and resource files are stored
+ */
+public class JRTClassFileContainer extends JVMClassFileContainer {
+
+    public JRTClassFileContainer() {
+        super("jrt", "jrt:/");
+    }
+
+    @Override
+    public ClassFileMatch getMatch(String clsName) {
+        FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+        byte[] data;
+        try {
+            data = Files.readAllBytes(fs.getPath("modules", getClassEntryURL(clsName)));
+            return new JVMClassFileMatch(clsName, getClassURL(clsName), data);
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/gov/nasa/jpf/jvm/JVMClassFileContainer.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassFileContainer.java
@@ -80,6 +80,8 @@ public abstract class JVMClassFileContainer extends ClassFileContainer {
    *     jar:file:/path/to/jpf-classes.jar!/java.base/java/lang/Object.class
    *
    *     /path/to/build/tests/TypeNameTest.class
+   *
+   *     jrt:/java.base/java/lang/Class.class
    */
   @Override
   public String getClassURL (String typeName){

--- a/src/main/gov/nasa/jpf/vm/ClassLoaderInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassLoaderInfo.java
@@ -31,6 +31,7 @@ import gov.nasa.jpf.Config;
 import gov.nasa.jpf.JPF;
 import gov.nasa.jpf.JPFException;
 import gov.nasa.jpf.SystemAttribute;
+import gov.nasa.jpf.jvm.JRTClassFileContainer;
 import gov.nasa.jpf.util.JPFLogger;
 import gov.nasa.jpf.util.SparseIntVector;
 import gov.nasa.jpf.util.StringSetMatcher;
@@ -647,6 +648,9 @@ public class ClassLoaderInfo
     }
   }
 
+  /**
+   * @return a {@link ClassFileMatch} or null if a match is not found
+   */
   protected ClassFileMatch getMatch(String typeName) {
     if(ClassInfo.isBuiltinClass(typeName)) {
       return null;
@@ -657,6 +661,12 @@ public class ClassLoaderInfo
       match = cp.findMatch(typeName); 
     } catch (ClassParseException cfx){
       throw new JPFException("error reading class " + typeName, cfx);
+    }
+
+    if (match == null) {
+      // match not found in the classpath
+      // try to load from the run-time image
+      match = new JRTClassFileContainer().getMatch(typeName);
     }
 
     return match;


### PR DESCRIPTION
If a match is not found when resolving classes from the classpath, try to load that class from the run-time image.

References:
http://openjdk.java.net/jeps/220

Fixes: #94 