### PR TITLE
Rename JPF_sun_reflect_Reflection to JPF_jdk_internal_reflect_Reflection

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_jdk_internal_reflect_Reflection.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_jdk_internal_reflect_Reflection.java
@@ -20,7 +20,7 @@ package gov.nasa.jpf.vm;
 
 import gov.nasa.jpf.annotation.MJI;
 
-public class JPF_sun_reflect_Reflection extends NativePeer {
+public class JPF_jdk_internal_reflect_Reflection extends NativePeer {
 
   @MJI
   public int getCallerClass__I__Ljava_lang_Class_2(MJIEnv env, int clsObjRef, int offset){


### PR DESCRIPTION
This fixes the run-time error "java.lang.UnsatisfiedLinkError: cannot find native jdk.internal.reflect.Reflection.getCallerClass"

```
[junit] java.lang.UnsatisfiedLinkError: cannot find native jdk.internal.reflect.Reflection.getCallerClass
[junit]     at jdk.internal.reflect.Reflection.getCallerClass(no peer)
```
Fixes: #103 