### PR TITLE
Implement missing, and/or unlinked native methods in Unsafe 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -161,6 +161,9 @@
            includes="*,gov/nasa/jpf/**,classloader_specific_tests/**">
       <compilerarg value="-Xlint:all,-serial,-rawtypes,-unchecked"/>
 
+      <compilerarg value="--add-exports"/>
+      <compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED"/>
+
       <include name="*gov/nasa/jpf/**"/>
       <include name="classloader_specific_tests/**"/>
       <include name="java8/**" if="have_java8"/>

--- a/src/classes/modules/java.base/jdk/internal/misc/Unsafe.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/Unsafe.java
@@ -41,6 +41,11 @@ public class Unsafe {
   // a numeric id for the corresponding FieldInfo here
   public native int fieldOffset (Field f);
   public native long objectFieldOffset (Field f);
+  public native long objectFieldOffset(Class<?> c, String name);
+
+  public final native boolean compareAndSetInt(Object o, long offset, int expected, int x);
+  public final native boolean compareAndSetLong(Object o, long offset, long expected, long x);
+  public final native boolean compareAndSetObject(Object o, long offset, Object expected, Object x);
 
   // those do the usual CAS magic
   public native boolean compareAndSwapObject (Object oThis, long offset, Object expect, Object update);
@@ -72,6 +77,10 @@ public class Unsafe {
 
   public native Object getObject(Object obj, long l);
   public native Object getObjectVolatile(Object obj, long l);
+
+  public final Object getObjectAcquire(Object o, long offset) {
+    return getObjectVolatile(o, offset);
+  }
 
   @Deprecated
   public Object getObject(Object obj, int offset) {
@@ -208,8 +217,11 @@ public class Unsafe {
   public native int arrayBaseOffset(Class<?> clazz);
 
   public native int arrayIndexScale(Class<?> clazz);
-  
-  
+
+  public final void putObjectRelease(Object o, long offset, Object x) {
+    putObjectVolatile(o, offset, x);
+  }
+
   //--- java.nio finally breaks object boundaries  - hello, evil pointer arithmetic
   
   /**

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -490,7 +490,7 @@ public class JPF_java_lang_Class extends NativePeer {
   }
   
   // this is only used for system classes such as java.lang.reflect.Method
-  ClassInfo getInitializedClassInfo (MJIEnv env, String clsName){
+  static ClassInfo getInitializedClassInfo (MJIEnv env, String clsName){
     ThreadInfo ti = env.getThreadInfo();
     Instruction insn = ti.getPC();
     ClassInfo ci = ClassLoaderInfo.getSystemResolvedClassInfo( clsName);

--- a/src/tests/gov/nasa/jpf/test/java/misc/UnsafeTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/misc/UnsafeTest.java
@@ -1,0 +1,68 @@
+package gov.nasa.jpf.test.java.misc;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import jdk.internal.misc.Unsafe;
+import org.junit.Test;
+
+public class UnsafeTest extends TestJPF {
+
+    private class TestClass {
+        int intVar = 0;
+    }
+
+    private final Unsafe unsafe = Unsafe.getUnsafe();
+
+    /**
+     * Test NativePeer method for {@link Unsafe#objectFieldOffset(java.lang.Class, java.lang.String)}
+     */
+    @Test
+    public void objectFieldOffset() {
+        if (verifyNoPropertyViolation()) {
+            unsafe.objectFieldOffset(TestClass.class, "intVar");
+        }
+    }
+
+    /**
+     * Test NativePeer method for {@link Unsafe#getInt(Object, long)}
+     */
+    @Test
+    public void getInt() {
+        if (verifyNoPropertyViolation()) {
+            TestClass o = new TestClass();
+            long intFieldOffset = unsafe.objectFieldOffset(TestClass.class, "intVar");
+
+            assert unsafe.getInt(o, intFieldOffset) == 0;
+        }
+    }
+
+    /**
+     * Test NativePeer method for {@link Unsafe#putInt(Object, long, int)}
+     */
+    @Test
+    public void putInt() {
+        if (verifyNoPropertyViolation()) {
+            TestClass o = new TestClass();
+            long intFieldOffset = unsafe.objectFieldOffset(TestClass.class, "intVar");
+            int x = 77;
+
+            unsafe.putInt(o, intFieldOffset, x);
+            assert o.intVar == x;
+        }
+    }
+
+    /**
+     * Test NativePeer method for {@link Unsafe#compareAndSetInt(Object, long, int, int)}
+     */
+    @Test
+    public void compareAndSetInt() {
+        if (verifyNoPropertyViolation()) {
+            TestClass o = new TestClass();
+            long intFieldOffset = unsafe.objectFieldOffset(TestClass.class, "intVar");
+            int expected = 0;
+            int x = 3;
+
+            unsafe.compareAndSetInt(o, intFieldOffset, expected, x);
+            assert o.intVar == 3;
+        }
+    }
+}


### PR DESCRIPTION
This implements the missing methods in Unsafe model class to prevent NoSuchMethodError(s), and their respective NativePeer methods in JPF_jdk_internal_misc_Unsafe to prevent UnsatisfiedLinkError(s).
```
[junit] java.lang.NoSuchMethodError: jdk.internal.misc.Unsafe.objectFieldOffset(Ljava/lang/Class;Ljava/lang/String;)J
```
```
[junit] java.lang.UnsatisfiedLinkError: cannot find native jdk.internal.misc.Unsafe.objectFieldOffset
```
Fixes: #99 

