### PR TITLE
Open jdk.internal.misc to UNNAMED module in tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -477,6 +477,8 @@
         </fileset>
       </batchtest>
 
+      <jvmarg value="--add-opens"/>
+      <jvmarg value="java.base/jdk.internal.misc=ALL-UNNAMED"/>
     </junit>
 
     <fail if="test.failed" />


### PR DESCRIPTION
This opens java.base/jdk.internal.misc to the UNNAMED module (in junit ant target --test), so to prevent:

    [junit] java.lang.IllegalAccessError: class gov.nasa.jpf.vm.JPF_java_util_Random (in unnamed module)
            cannot access class jdk.internal.misc.Unsafe (in module java.base)
            because module java.base does not export jdk.internal.misc to unnamed module

AND:

    [junit] gov.nasa.jpf.JPFException: cannot access java.util.Random
            internals: java.lang.reflect.InaccessibleObjectException: Unable to make
            field private static final jdk.internal.misc.Unsafe
            jdk.internal.misc.Unsafe.theUnsafe accessible: module java.base does not
            "opens jdk.internal.misc" to unnamed module

Fixes: #107 