### PR TITLE
Add accessor methods for SharedSecrets#javaNetURLAccess

### DIFF
--- a/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
@@ -52,6 +52,7 @@ public class SharedSecrets {
   private static JavaUtilJarAccess javaUtilJarAccess;
   private static JavaLangAccess javaLangAccess;
   private static JavaIOAccess javaIOAccess;
+  private static JavaNetURLAccess javaNetURLAccess;
   private static JavaIODeleteOnExitAccess javaIODeleteOnExitAccess;
   private static JavaNetAccess javaNetAccess;
   private static JavaIOFileDescriptorAccess javaIOFileDescriptorAccess;
@@ -77,6 +78,15 @@ public class SharedSecrets {
     return javaNetAccess;
   }
 
+  public static void setJavaNetURLAccess(JavaNetURLAccess jnua) {
+    javaNetURLAccess = jnua;
+  }
+
+  public static JavaNetURLAccess getJavaNetURLAccess() {
+    if (javaNetURLAccess == null)
+      unsafe.ensureClassInitialized(java.net.URL.class);
+    return javaNetURLAccess;
+  }
 
   public static JavaUtilJarAccess javaUtilJarAccess() {
     if (javaUtilJarAccess == null) {


### PR DESCRIPTION
Adds SharedSecrets#setJavaNetURLAccess and SharedSecrets#getJavaNetURLAccess methods to jdk.internal.misc.SharedSecrets model clsas.

This fixes:

    [junit] java.lang.NoSuchMethodException:
            jdk.internal.misc.SharedSecrets.setJavaNetURLAccess(Ljdk/internal/misc/JavaNetURLAccess;)V

Fixes: #109 