### PR TITLE
Rename JPF_sun_misc_VM to JPF_jdk_internal_misc_VM

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_jdk_internal_misc_VM.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_jdk_internal_misc_VM.java
@@ -24,7 +24,7 @@ import gov.nasa.jpf.vm.NativePeer;
 /**
  * this is just a placeholder for now, we don't support its functionality
  */
-public class JPF_sun_misc_VM extends NativePeer {
+public class JPF_jdk_internal_misc_VM extends NativePeer {
   
   @MJI
   public void initialize____V (MJIEnv env, int clsObjRef){


### PR DESCRIPTION
This fixes the JUnit error:

    [junit] java.lang.UnsatisfiedLinkError: cannot find native jdk.internal.misc.VM.initialize

Fixes: #115 