### PR TITLE
Add native peer JPF_java_lang_StringUTF16

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StringUTF16.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StringUTF16.java
@@ -1,0 +1,16 @@
+package gov.nasa.jpf.vm;
+
+import gov.nasa.jpf.annotation.MJI;
+
+import java.nio.ByteOrder;
+
+public class JPF_java_lang_StringUTF16 extends NativePeer {
+
+    /**
+     * NativePeer method for {@link StringUTF16#isBigEndian()}
+     */
+    @MJI
+    public static boolean isBigEndian____Z (MJIEnv env, int cref) {
+        return ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+    }
+}


### PR DESCRIPTION
This adds a NativePeer class for java.lang.StringUTF16.

Also adds a native peer method for StringUTF16#isBigEndian() to fix:

    [junit] java.lang.UnsatisfiedLinkError:
            cannot find native java.lang.StringUTF16.isBigEndian

Fixes: #114 