### PR TITLE
Add NativePeer JPF_java_lang_StackStreamFactory

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StackStreamFactory.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StackStreamFactory.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpf.vm;
+
+import gov.nasa.jpf.annotation.MJI;
+
+/**
+ * NativePeer for {@link StackStreamFactory}
+ */
+public class JPF_java_lang_StackStreamFactory extends NativePeer {
+
+    /**
+     * NativePeer method for {@link StackStreamFactory#checkStackWalkModes()}
+     */
+    @MJI
+    public static boolean checkStackWalkModes____Z(MJIEnv env, int cref) {
+        // supposed to return false, if StackWalker mode values do not match with JVM
+        return true;
+    }
+}


### PR DESCRIPTION
Add a native peer method for StackStreamFactory#checkStackWalkModes to fix #113 :

```
[junit] java.lang.UnsatisfiedLinkError:
        cannot find native java.lang.StackStreamFactory.checkStackWalkModes
```