### PR TITLE
Add java.lang.Class#getModule to MJI model class

### DIFF
--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -60,6 +60,9 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   
   private String name;
 
+  // set by VM
+  private transient Module module;
+
   private ClassLoader classLoader;
   
   /**
@@ -358,5 +361,9 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   public boolean isSynthetic (){
     final int SYNTHETIC = 0x00001000;
     return (getModifiers() & SYNTHETIC) != 0;
+  }
+
+  public Module getModule() {
+    return module;
   }
 }


### PR DESCRIPTION
Add method java.lang.Class#getModule to  MJI model class for java.lang.Class

This also fixes #124 :

```
[junit] java.lang.NoSuchMethodError:
        java.lang.Class.getModule()Ljava/lang/Module;
```