### PR TITLE
Update String#length to comply with JEP 254

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -207,10 +207,12 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 	String(int offset, int count, char[] value) {
 		this(value, offset, count);
 	}
+
 	@Override
 	public int length() {
-		return value.length;
+		return value.length >> coder();
 	}
+
 	public boolean isEmpty() {
 		return value.length == 0;
 	}


### PR DESCRIPTION
The value returned by java.lang.String#length in the MJI model class for java.lang.String is incorrect, as the value field of String is now a byte array instead of a char array.

This updates String#length method to comply with JEP 254.

Fixes: #128 