### PR TITLE
Add method java.lang.String.getBytes(byte[], int, byte)

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -241,6 +241,19 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 		return StringCoding.encode(x, coder(), value);
 	}
 
+	/**
+	 * If two coders are different and target is big enough,
+	 * invoker guarantees that the target is in UTF16
+	 */
+	void getBytes(byte dst[], int dstBegin, byte coder) {
+		assert coder == UTF16;
+		if (coder() == coder) {
+			System.arraycopy(value, 0, dst, dstBegin << coder, value.length);
+		} else { // this.coder == LATIN1 && coder == UTF16
+			StringLatin1.inflate(value, 0, dst, dstBegin, value.length);
+		}
+	}
+
 	native public byte[] getBytes();
 	@Override
 	native public boolean equals(Object anObject);


### PR DESCRIPTION
Add method java.lang.String.getBytes(byte[], int, byte) to MJI model class for java.lang.String

This also fixes #134:
```
[junit] java.lang.NoSuchMethodError: java.lang.String.getBytes([BIB)V
[junit] at java.lang.AbstractStringBuilder.putStringAt(AbstractStringBuilder.java:1641)
```