### PR TITLE
Add method java.lang.String#String(byte[], byte)

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -185,6 +185,11 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 		this.coder = x.coder;
 	}
 
+	String(byte[] value, byte coder) {
+		this.value = value;
+		this.coder = coder;
+	}
+
 	String(char[] value, int off, int len, Void sig) {
 		if (len == 0) {
 			this.value = "".value;


### PR DESCRIPTION
Add package private constructor `java.lang.String#String(byte[], byte)` to MJI model class for java.lang.String

This also fixes #135:
```
[junit] java.lang.NoSuchMethodException: Calling java.lang.String.<init>([BB)V
[junit]     at java.lang.StringLatin1.newString(StringLatin1.java:549)
```