### PR TITLE
Fix invalid implementation of NativePeer method for String#concat

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
@@ -317,7 +317,7 @@ public class JPF_java_lang_String extends NativePeer {
   @MJI
   public int concat__Ljava_lang_String_2__Ljava_lang_String_2 (MJIEnv env, int objRef, int strRef) {
     String thisStr = env.getStringObject(objRef);
-    String otherStr = env.getStringObject(objRef);
+    String otherStr = env.getStringObject(strRef);
 
     String result = thisStr.concat(otherStr);
     return env.newString(result);


### PR DESCRIPTION
When constructing the JVM string object `otherStr` , `strRef` should be used instead of `objRef`.

https://github.com/javapathfinder/jpf-core/blob/a95fd23e014d39fb01754125820cbe678dd559ab/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java#L317-L324

Fixes: #141 