### PR TITLE
Fix invalid implementation of NativePeer method for String#equals

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
@@ -170,7 +170,7 @@ public class JPF_java_lang_String extends NativePeer {
     }
 
     String s1 = env.getStringObject(objRef);
-    String s2 = env.getStringObject(objRef);
+    String s2 = env.getStringObject(argRef);
 
     return s1.equals(s2);
   }


### PR DESCRIPTION
When constructing the JVM string object 's2' in
gov.nasa.jpf.vm.JPF_java_lang_String#equals__Ljava_lang_Object_2__Z,
`argRef` should be used instead of `objRef`.

https://github.com/javapathfinder/jpf-core/blob/a95fd23e014d39fb01754125820cbe678dd559ab/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java#L166-L173

Fixes: #140 