### PR TITLE
Remove unnecessary assertion in String#getBytes(byte[], int, byte)

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -251,10 +251,10 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 	 * invoker guarantees that the target is in UTF16
 	 */
 	void getBytes(byte dst[], int dstBegin, byte coder) {
-		assert coder == UTF16;
 		if (coder() == coder) {
 			System.arraycopy(value, 0, dst, dstBegin << coder, value.length);
-		} else { // this.coder == LATIN1 && coder == UTF16
+		} else {
+			assert this.coder == LATIN1 && coder == UTF16;
 			StringLatin1.inflate(value, 0, dst, dstBegin, value.length);
 		}
 	}


### PR DESCRIPTION
https://github.com/javapathfinder/jpf-core/blob/9ebb98cb53b952ea3d7c7dc06aa7b822ee696395/src/classes/modules/java.base/java/lang/String.java#L249-L260

Our initial conclusion that the coder is always UTF16 is wrong. As it states "If two coders are **different** and the target is big enough, invoker guarantees that the target is in UTF16 ". So the invoker guarantees not to call when the source encoding is UTF-8 and the target is in LATIN-1.

But what if the source and target encoding are in "UTF-8". So the assertion statement needs to be removed.

This also fixes:

    [junit] java.lang.AssertionError
    [junit]     at java.lang.String.getBytes(String.java:254)

The error can be seen on ObjectStreamTest, ClassLoaderTest, StringTest and in a few other tests.
