### PR TITLE
Fixes null captured parameters

### DIFF
--- a/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
+++ b/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
@@ -61,8 +61,12 @@ public class FunctionObjectFactory {
       } else if (typeName.equals("boolean")) {
         fields.setBooleanValue(i, (Boolean)freeVarValues[i]);
       } else {
-        int val = ((ElementInfo)freeVarValues[i]).getObjectRef();
-        fields.setReferenceValue(i, val);
+        if(freeVarValues[i] == null) {
+          fields.setReferenceValue(i, MJIEnv.NULL); 
+        } else {
+          int val = ((ElementInfo)freeVarValues[i]).getObjectRef();
+          fields.setReferenceValue(i, val);
+        }
       }
     }
   }

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -19,6 +19,8 @@ package java8;
 
 import gov.nasa.jpf.util.test.TestJPF;
 
+import java.util.function.Supplier;
+
 import org.junit.Test;
 
 /**
@@ -293,5 +295,17 @@ public class LambdaTest extends TestJPF{
       
       assertSame(fi1,fi2);
     }
+  }
+  
+  @Test
+  public void testNullCaptureValues() {
+    if(verifyNoPropertyViolation()) {
+      Supplier<String> provider = getStringProvider(null);
+      assertEquals(provider.get(), "It was null");
+    }
+  }
+
+  private Supplier<String> getStringProvider(String object) {
+    return () -> object == null ? "It was null" : object;
   }
 }


### PR DESCRIPTION
Fixes and unit test for #147. As mentioned in the issue, there was no null check when unpacking object values.