### PR TITLE
Fixes setCause on default exception

### DIFF
--- a/src/classes/java/lang/Throwable.java
+++ b/src/classes/java/lang/Throwable.java
@@ -44,7 +44,7 @@ public class Throwable {
     } catch (ClassNotFoundException e) {
       throw new NoClassDefFoundError("java.lang.StackTraceElement");
     }
-     
+    cause = this;
     fillInStackTrace();
   }
 

--- a/src/tests/gov/nasa/jpf/test/java/lang/ThrowableTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ThrowableTest.java
@@ -1,0 +1,15 @@
+package gov.nasa.jpf.test.java.lang;
+
+import org.junit.Test;
+
+import gov.nasa.jpf.util.test.TestJPF;
+
+public class ThrowableTest extends TestJPF {
+  @Test
+  public void testSetCause() {
+    if(verifyNoPropertyViolation()) {
+      RuntimeException e = new RuntimeException();
+      e.initCause(new NullPointerException());
+    }
+  }
+}


### PR DESCRIPTION
Fixes #148. We just need to set cause in the no-arg throwable constructor to this.