### PR TITLE
Fixes default method resolution

### DIFF
--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -1096,7 +1096,7 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
       if (miIfc != null && !miIfc.isAbstract() && !miIfc.isPrivate() && !miIfc.isStatic()){
         if (mi != null && !mi.equals(miIfc)){
           if(miIfc.getClassInfo().isSubInterfaceOf(mi.getClassInfo())) {
-            miIfc = mi;
+            mi = miIfc;
           } else if(mi.getClassInfo().isSubInterfaceOf(miIfc.getClassInfo())) {
             continue;
           } else {

--- a/src/tests/java8/DefaultMethodTest.java
+++ b/src/tests/java8/DefaultMethodTest.java
@@ -140,7 +140,63 @@ public class DefaultMethodTest extends TestJPF {
       o.bar();
     }
   }
+  // -- most specific implementations
+  
+  public static interface Intf1 {
+    default int getInt() {
+      return 4;
+    }
+  }
+  
+  public static interface Intf2 extends Intf1 {
+    @Override
+    default int getInt() {
+      return 3;
+    }
+  }
+  public static abstract class A implements Intf1 {
+    
+  }
+  
+  public static class B extends A implements Intf2 {
+  }
+  
+  @Test
+  public void testMostSpecificImplementationResolution() {
+    if(verifyNoPropertyViolation()) {
+      B b = new B();
+      int x = b.getInt();
+      assertEquals(x, 3);
+    }
+  }
 
+  // --- inherited default methods
+  
+  interface SuperIntf {
+    default String getString() {
+      return "Hello World";
+    }
+  }
+  
+  interface SubIntf extends SuperIntf {
+    default int getZero() {
+      return 0;
+    }
+  }
+  
+  public class ConcreteClass implements SubIntf {
+    
+  }
+  
+  @Test
+  public void testInheritedDefaultMethod() {
+    if(verifyNoPropertyViolation()) {
+      ConcreteClass cls = new ConcreteClass();
+      assertEquals(cls.getString(), "Hello World");
+    }
+  }
+  
   // <2do> how to test IncompatibleClassChangeError without explicit classfile restore?
 }
+
 


### PR DESCRIPTION
Fixes #154. Now when multiple potential default method resolutions, we check whether one type is a subinterface of the other and select the more specific type. If the two types are not in a subtyping relation, we fail as before.

In addition, the looping algorithm was changed because the old version did not consider super interfaces. This commit includes a unit test to test this behavior.