### PR TITLE
Rectifies the java.lang.NoSuchMethodError when usinf printf

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/classes/java/util/regex/Matcher.java
+++ b/src/classes/java/util/regex/Matcher.java
@@ -67,6 +67,8 @@ public class Matcher {
   public native boolean matches();
   
   public native boolean find();
+
+  public native boolean find(int start);
   
   public native boolean lookingAt();
   

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
@@ -74,6 +74,12 @@ public class JPF_java_util_regex_Matcher extends NativePeer {
   }
   
   @MJI
+  public boolean find__I__Z (MJIEnv env, int objref, int i) {
+	Matcher matcher = getInstance( env, objref);
+    return matcher.find(i);
+  }
+
+  @MJI
   public boolean find____Z (MJIEnv env, int objref) {
 	Matcher matcher = getInstance( env, objref);
     return matcher.find();

--- a/src/tests/gov/nasa/jpf/test/java/io/PrintStreamTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/io/PrintStreamTest.java
@@ -30,13 +30,13 @@ import org.junit.Test;
  */
 public class PrintStreamTest extends TestJPF {
 
-  @Test // currently fails with: java.lang.NoSuchMethodError: java.util.regex.Matcher.find(I)Z
+  @Test 
   public void testPrintCharFormat () {
     if (verifyNoPropertyViolation()){
 	ByteArrayOutputStream baos = new ByteArrayOutputStream(1);
 	PrintStream baps = new PrintStream(baos, true);
-//	baps.printf("%c", 'a'); // fails
-//	assert (baos.toByteArray()[0] == 97);
+	baps.printf("%c", 'a'); 
+	assert (baos.toByteArray()[0] == 97);
     }
   }
 }


### PR DESCRIPTION
The model and peer classes java.util.regex.Matcher are modified to accommodate the overloading of the function find() , the lack of which was causing the error.