### PR TITLE
Implements a jpf example ConcurrentCount

### DIFF
--- a/src/examples/ConcurrentCount.java
+++ b/src/examples/ConcurrentCount.java
@@ -1,0 +1,58 @@
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ConcurrentCount {
+	static final int COUNT = 30000;
+	volatile static int count = COUNT;
+	volatile static AtomicBoolean lock = new AtomicBoolean(false); 
+	static int a = 0;
+	static int b = 0;
+	
+	public static void main(String args[]) {
+		
+		new Thread() {
+			
+			@Override
+			public void run() {
+				while(count > 0) {
+					if (lock.get()) continue;
+					lock.set(true);
+					decreaseCount();
+					a++;
+					lock.set(false);
+					
+					
+				}
+			}
+		}.start();
+		
+        new Thread() {
+			
+			@Override
+			public void run() {
+				while(count > 0) {
+					if (lock.get()) continue;
+					lock.set(true);
+					decreaseCount();
+					b++;
+					lock.set(false);
+					
+					
+				}
+			}
+		}.start();
+		
+		while(count > 0);
+		//System.out.println("a = " + a);
+		//System.out.println("b = " + b);
+		//System.out.println("a + b = " + (a + b));
+		//System.out.println("count = " + count);
+
+		//assert a + b == COUNT;
+	}
+	
+	private static synchronized void decreaseCount() {
+		count--;
+	}
+
+}
+

--- a/src/examples/ConcurrentCount.java
+++ b/src/examples/ConcurrentCount.java
@@ -47,7 +47,8 @@ public class ConcurrentCount {
 		//System.out.println("a + b = " + (a + b));
 		//System.out.println("count = " + count);
 
-		//assert a + b == COUNT;
+		//Checks for concurrency error (which should be found when using model checking)
+		assert a + b == COUNT;
 	}
 	
 	private static synchronized void decreaseCount() {

--- a/src/examples/ConcurrentCount.jpf
+++ b/src/examples/ConcurrentCount.jpf
@@ -1,0 +1,1 @@
+target = ConcurrentCount


### PR DESCRIPTION
The jpf example CocnurrentCount can be used to compare the performance of different jpf-core implementations/search techniques. The state-space's size can be greatly varied by changing the variable "COUNT" which further helps in making comparisons.