### PR TITLE
Fix issue #187: use ubuntu trusty version for travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
There's a known issue in travis xenial environment. It only supports JDK versions 9-11.
