### PR TITLE
Fixed off-by-one error in String.lastIndexOf() method (#197)

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_String.java
@@ -345,7 +345,7 @@ public class JPF_java_lang_String extends NativePeer {
       fromIndex = len - 1;
     }
 
-    for (int i = fromIndex; i > 0; i--) {
+    for (int i = fromIndex; i >= 0; i--) {
       if (values[i] == c) { return i; }
     }
 

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -86,6 +86,16 @@ public class StringTest extends TestJPF {
 			assert i2 == -1;
 		}
 	}
+	
+	@Test
+	public void testLastIndexOf() {
+		if (verifyNoPropertyViolation()) {
+			String val = "-1";
+			int i = val.lastIndexOf('-');
+			
+			assert(i == 0); // test against off-by-one error (issue #197)
+		}
+	}
 
 	@Test
 	public void testCompareTo() {


### PR DESCRIPTION
Fixed an off-by-one error in the model class implementation of the method `String.lastIndexOf()` in `JPF_java_lang_String`. Initially the for-loop counter always excludes 0 as the last index, whereas it should have been included in the search.