### PR TITLE
Fixed zero-capacity error in StringBuilder.append(char c) method (#201)

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StringBuilder.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_StringBuilder.java
@@ -136,6 +136,11 @@ public class JPF_java_lang_StringBuilder extends NativePeer {
     int i;
     int n = count +1;
     
+    if (alen == 0) {
+      $init____V (env, objref);
+      aref = env.getReferenceField(objref, "value");
+      alen = env.getArrayLength(aref);
+    }
     if (n < alen) {
       env.setCharArrayElement(aref, count, c);
     } else {

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -387,4 +387,16 @@ public class StringTest extends TestJPF {
       assertTrue( s.contentEquals(sb));
     }
   }
+  
+  @Test
+  public void testStringBuilderAppendChar() {
+    if (verifyNoPropertyViolation()){
+      StringBuilder sb = new StringBuilder(0);
+      sb.append('[');
+      sb.append(']');
+      String s = sb.toString();
+      
+      assertTrue( s.equals("[]"));
+    }
+  }
 }


### PR DESCRIPTION
Fixed a zero-capacity error in the model class implementation of the method `StringBuilder.append(char c)` in `JPF_java_lang_StringBuilder`. Initially when capacity is set to 0 for the constructor during a StringBuilder object instantiation, the JPF's implementation for the `append(char c)` will throw an `illegal array offset: 0` exception when the method is called. The behavior for the standard StringBuilder library is to allow such appends even when the capacity has been first set to 0. Thus, for the JPF's implementation, we first need to allocate a default array if the initial capacity is 0.