### PR TITLE
Added a recursive look-up mechanism for the java.lang.ClassLoader.defineClass() native method and the necessary unit test testDefineClass for this change (#199)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ buildscript {
 
 dependencies {
     testImplementation "junit:junit:4.12"
+    compile "org.ow2.asm:asm:7.1"
+}
+
+task copyLibs(type: Copy) {
+    from configurations.compile
+    into 'build'
 }
 
 apply plugin: "com.palantir.git-version"
@@ -203,6 +209,7 @@ task buildJars {
     dependsOn createJpfJar
     dependsOn createRunJpfJar
     dependsOn createRunTestJar
+	dependsOn copyLibs
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ buildscript {
 
 dependencies {
     testImplementation "junit:junit:4.12"
-    compile "org.ow2.asm:asm:7.1"
+    testCompile "org.ow2.asm:asm:7.1"
 }
 
 task copyLibs(type: Copy) {
-    from configurations.compile
+    from configurations.testCompile
     into 'build'
 }
 
@@ -209,7 +209,7 @@ task buildJars {
     dependsOn createJpfJar
     dependsOn createRunJpfJar
     dependsOn createRunTestJar
-	dependsOn copyLibs
+    dependsOn copyLibs
 }
 
 test {

--- a/jpf.properties
+++ b/jpf.properties
@@ -22,13 +22,13 @@ jpf-core.native_classpath=\
 
 jpf-core.classpath=\
   ${jpf-core}/build/jpf-classes.jar;\
-  ${jpf-core}/build/asm-7.1.jar;\
   ${jpf-core}/build/examples
 
 jpf-core.sourcepath=\
   ${jpf-core}/src/examples
 
 jpf-core.test_classpath=\
+  ${jpf-core}/build/asm-7.1.jar;\
   ${jpf-core}/build/tests
 
 jpf-core.peer_packages = gov.nasa.jpf.vm,<model>,<default>

--- a/jpf.properties
+++ b/jpf.properties
@@ -22,6 +22,7 @@ jpf-core.native_classpath=\
 
 jpf-core.classpath=\
   ${jpf-core}/build/jpf-classes.jar;\
+  ${jpf-core}/build/asm-7.1.jar;\
   ${jpf-core}/build/examples
 
 jpf-core.sourcepath=\

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassLoaderTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassLoaderTest.java
@@ -181,6 +181,15 @@ public class ClassLoaderTest extends TestJPF {
       assertTrue(cls.getName().equals("sun.reflect.GroovyMagic"));
     }
   }
+	
+  @Test
+  public void testDefineClassError() {
+    if (verifyUnhandledException("java.lang.LinkageError")) {
+      TestClassLoader classLoader = new TestClassLoader();
+      Class<?> cls = classLoader.loadMagic();
+      Class<?> cls2 = classLoader.loadMagic();
+    }
+  }
 
   class TestClassLoader extends ClassLoader {
       


### PR DESCRIPTION
1) The recursive look-up is attempted just in the native method `defineClass()` in the model class `JPF_java_lang_ClassLoader` through exception catching and handling. The look-up is attempted in the `SystemClassLoader` if the current `ClassLoader` fails to find the required classes. If the class still could not be found, the method would then throw a JPF's `java.lang.ClassNotFoundException` properly.

2) When the `ClassInfo` has been defined, we just return the necessary object reference number and not return a `LinkageError` exception as what it did before.

3) I have also created a unit test for the `defineClass()` method. All the unit tests have been run and they successfully passed.

4) There are a few minor changes in the build.gradle and jpf.properties files to download the necessary ASM library (for class writing), and get the right `classpath` for it.