### PR TITLE
fixed random search where only one path is explored even with limit > 1

### DIFF
--- a/src/main/gov/nasa/jpf/search/RandomSearch.java
+++ b/src/main/gov/nasa/jpf/search/RandomSearch.java
@@ -29,7 +29,8 @@ import gov.nasa.jpf.vm.RestorableVMState;
  * going forward() until there is no next state then it restarts the search 
  * until it hits a certain number of paths executed
  *
- * <2do> this needs to be updated & tested
+ * To explore different paths, cg.randomize_choices shouldn't be set to NONE
+ *
  */
 public class RandomSearch extends Search {
   int path_limit = 0;
@@ -55,7 +56,7 @@ public class RandomSearch extends Search {
     
     notifySearchStarted();
     while (!done) {
-      if ((depth < depthLimit) && forward()) {
+      if (!isEndState() && (depth < depthLimit) && forward()) {
         notifyStateAdvanced();
 
         if (currentError != null){
@@ -66,12 +67,12 @@ public class RandomSearch extends Search {
           }
         }
 
-        if (isEndState()){
-          return;
-        }
+//        if (isEndState()){
+//          return;
+//        }
 
         depth++;
-
+        //System.out.println("path " + paths + ", depth " + depth);
       } else { // no next state or reached depth limit
         // <2do> we could check for more things here. If the last insn wasn't
         // the main return, or a System.exit() call, we could flag a JPFException
@@ -85,6 +86,7 @@ public class RandomSearch extends Search {
         depth = 1;
         vm.restoreState(init_state);
         vm.resetNextCG();
+
       }
     }
     notifySearchFinished();

--- a/src/main/gov/nasa/jpf/search/RandomSearch.java
+++ b/src/main/gov/nasa/jpf/search/RandomSearch.java
@@ -66,13 +66,7 @@ public class RandomSearch extends Search {
             return;
           }
         }
-
-//        if (isEndState()){
-//          return;
-//        }
-
         depth++;
-        //System.out.println("path " + paths + ", depth " + depth);
       } else { // no next state or reached depth limit
         // <2do> we could check for more things here. If the last insn wasn't
         // the main return, or a System.exit() call, we could flag a JPFException
@@ -86,7 +80,6 @@ public class RandomSearch extends Search {
         depth = 1;
         vm.restoreState(init_state);
         vm.resetNextCG();
-
       }
     }
     notifySearchFinished();

--- a/src/tests/gov/nasa/jpf/test/mc/basic/StatelessTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/StatelessTest.java
@@ -47,4 +47,21 @@ public class StatelessTest extends TestJPF {
       assert Verify.getCounter(0) == 6;
     }
   }
+
+
+  @Test public void testStatelessRandomSearch () {
+    if (!isJPFRun()){
+      Verify.resetCounter(0);
+    }
+    if (verifyNoPropertyViolation("+search.class=.search.RandomSearch", "+search.RandomSearch.path_limit = 10", "+cg.randomize_choices = FIXED_SEED")){
+      int d = 0;
+      Verify.incrementCounter(0);
+    }
+    if (!isJPFRun()){
+      if (Verify.getCounter(0) != 11){ // path variable will be incremented to limit + 1
+        fail("wrong number of paths");
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Right now the `RandomSearch` always returns after finishing one path, this PR tries to fix this problem and allow it to explore mutiple paths specified by `search.RandomSearch.path_limit`. The previous code will fail the added test but should pass after merged. 

Now after `cg.randomize_choices` set to not `NONE` , the search will randomly try different paths.