### PR TITLE
Fix testSimpleReadbackOk Test

### DIFF
--- a/src/classes/sun/misc/SharedSecrets.java
+++ b/src/classes/sun/misc/SharedSecrets.java
@@ -171,4 +171,8 @@ public class SharedSecrets {
 
     return javaOISAccess;
   }
+
+  public void setJavaObjectInputStreamReadString(sun.misc.JavaObjectInputStreamReadString ignored) {
+      
+  }
 }


### PR DESCRIPTION
The failing test `testSimpleReadbackOk` throws `NoSuchMethodException`. It can be reproduced by running the following command.
`gradle test --tests gov.nasa.jpf.test.java.io.ObjectStreamTest.testSimpleReadbackOk --info`
My Java version is `openjdk 1.8.0_252`.
The stack trace is as follows
`gov.nasa.jpf.vm.NoUncaughtExceptionsProperty
    java.lang.NoSuchMethodException: sun.misc.SharedSecrets.setJavaObjectInputStreamReadString(Lsun/misc/JavaObjectInputStreamReadString;)V
        at java.io.ObjectInputStream.<clinit>(ObjectInputStream.java:3986)
	at gov.nasa.jpf.test.java.io.ObjectStreamTest.testSimpleReadbackOk(ObjectStreamTest.java:88)
        at java.lang.reflect.Method.invoke(gov.nasa.jpf.vm.JPF_java_lang_reflect_Method)
        at gov.nasa.jpf.util.test.TestJPF.runTestMethod(TestJPF.java:648)
`
The fix is to add the method `setJavaObjectInputStreamReadString` with an empty body in `SharedSecrets.java`. After applying this fix, the test passes.