### PR TITLE
Fix testBufferConstructor Test

### DIFF
--- a/src/classes/java/util/regex/Pattern.java
+++ b/src/classes/java/util/regex/Pattern.java
@@ -62,4 +62,23 @@ public class Pattern {
   public String toString() {
     return regex;
   }
+
+  public static String quote(String s) {
+    int slashEIndex = s.indexOf("\\E");
+    if (slashEIndex == -1)
+      return "\\Q" + s + "\\E";
+
+    StringBuilder sb = new StringBuilder(s.length() * 2);
+    sb.append("\\Q");
+    slashEIndex = 0;
+    int current = 0;
+    while ((slashEIndex = s.indexOf("\\E", current)) != -1) {
+      sb.append(s.substring(current, slashEIndex));
+      current = slashEIndex + 2;
+      sb.append("\\E\\\\E\\Q");
+    }
+    sb.append(s.substring(current, s.length()));
+    sb.append("\\E");
+    return sb.toString();
+  }
 }


### PR DESCRIPTION
The failing test `testBufferConstructor` throws `NoSuchMethodException`, which can be reproduced using the following command:
`gradle test --tests gov.nasa.jpf.test.java.nio.ByteBufferTest.testBufferConstructor --info`
I use Java version openjdk 1.8.0_252. The stacktrace is as follows:
`gov.nasa.jpf.vm.NoUncaughtExceptionsProperty
java.lang.NoSuchMethodException: java.util.regex.Pattern.quote(Ljava/lang/String;)Ljava/lang/String;`
`at java.util.Scanner.useLocale(Scanner.java:1196)`
`at java.util.Scanner.<init>(Scanner.java:540)`
`at java.util.Scanner.<init>(Scanner.java:702)`
`at gov.nasa.jpf.test.java.nio.ByteBufferTest.testBufferConstructor(ByteBufferTest.java:40)`
`at java.lang.reflect.Method.invoke(gov.nasa.jpf.vm.JPF_java_lang_reflect_Method)`
`at gov.nasa.jpf.util.test.TestJPF.runTestMethod(TestJPF.java:648)`

The fix is to add a static method `quote` in `Pattern.java`. The implementation is from http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/c46daef6edb5/src/share/classes/java/util/regex/Pattern.java. After applying the fix, the test passes.