### PR TITLE
add PolDet (Pollution Detection) implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,4 +243,26 @@ test {
     }
 }
 
+def PolDetJPFClasspath = "${buildDir}/tests:" + configurations.testRuntimeClasspath.findAll { it.name.endsWith('jar') && (it.name.contains('junit') || it.name.contains('hamcrest')) }.join(":")
+
+task testPolDet(type: Exec) {
+    group = "PolDet@JPF"
+    description = "Run PolDet on example tests."
+
+    dependsOn buildJars
+
+    commandLine 'java', '-jar', "${buildDir}/RunJPF.jar", "+classpath=${PolDetJPFClasspath}", "PolDetMain", "PolDetExamples"
+}
+
+task runPolDet(type: Exec) {
+    group = "PolDet@JPF"
+    description = "Run PolDet on a given test class."
+
+    dependsOn buildJars
+
+    def JPFClasspath = "${PolDetJPFClasspath}:" + project.findProperty("testClasspath") ?: ""
+
+    commandLine 'java', '-jar', "${buildDir}/RunJPF.jar", "+classpath=${JPFClasspath}", "PolDetMain", project.findProperty("testClass") ?: ""
+}
+
 defaultTasks "buildJars"

--- a/src/main/gov/nasa/jpf/vm/serialize/PolDetSerializer.java
+++ b/src/main/gov/nasa/jpf/vm/serialize/PolDetSerializer.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2021 Pu Yi
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You can find a copy of the GNU General Public License at
+ * <http://www.gnu.org/licenses/>.
+ */
+package gov.nasa.jpf.vm.serialize;
+
+
+import gov.nasa.jpf.JPFErrorException;
+import gov.nasa.jpf.util.FinalBitSet;
+import gov.nasa.jpf.vm.ClassInfo;
+import gov.nasa.jpf.vm.FieldInfo;
+import gov.nasa.jpf.vm.Fields;
+import gov.nasa.jpf.vm.StackFrame;
+import gov.nasa.jpf.vm.StaticElementInfo;
+import gov.nasa.jpf.vm.Statics;
+import gov.nasa.jpf.vm.ThreadInfo;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+
+/**
+ * The serializer used in PolDet, customized to ignore irrelevant parts of the state
+ *
+ * @author Pu Yi
+ */
+public class PolDetSerializer extends FilteringSerializer {
+
+  public enum PolDetPhase {
+    // capture the state before test run, collecting loaded classes along the way
+    PRESTATE,
+    // capture the state after the test run, serializing only from previously loaded classes
+    POSTSTATE
+  }
+  public PolDetPhase phaseOfPolDet;
+
+  public Set<String> loadedClasses = new HashSet<>();
+  public Set<String> ignoredFields = new HashSet<>(Arrays.asList("emptyAnnotations", "nInstances"));
+  public Set<String> ignoredMethods = new HashSet<>(Arrays.asList("main", "testStarted", "testFinished", "compareStates", "capturePreState"));
+
+  protected boolean isFrameIgnored (StackFrame frame) {
+    return frame.getClassName().startsWith("org.junit") || ignoredMethods.contains(frame.getMethodName());
+  }
+
+  @Override
+  protected void serializeStackFrames (ThreadInfo ti) {
+    processReference(ti.getThreadObjectRef());
+
+    for (StackFrame frame = ti.getTopFrame(); frame != null; frame = frame.getPrevious()) {
+      if (!isFrameIgnored(frame)) {
+        serializeFrame(frame);
+      }
+    }
+  }
+
+  protected boolean isStaticsIgnored (StaticElementInfo sei) {
+    String className = sei.toString();
+    return className.startsWith("org.junit") || className.toLowerCase().contains("cache");
+  }
+
+  @Override
+  protected void serializeStatics (Statics statics) {
+    int classCount = 0;
+    for (StaticElementInfo sei : statics.liveStatics()) {
+      if (phaseOfPolDet == PolDetPhase.PRESTATE) {
+        if (!isStaticsIgnored(sei)) {
+          classCount++;
+        }
+      } else {
+        if (loadedClasses.contains(sei.toString())) {
+          classCount++;
+        }
+      }
+    }
+    buf.add(classCount);
+    for (StaticElementInfo sei : statics.liveStatics()) {
+      if (phaseOfPolDet == PolDetPhase.PRESTATE) {
+        if (!isStaticsIgnored(sei)) {
+          loadedClasses.add(sei.toString());
+          serializeClass(sei);
+        }
+      } else {
+        if (loadedClasses.contains(sei.toString())) {
+          serializeClass(sei);
+        }
+      }
+    }
+  }
+
+  protected String getFieldName (FieldInfo[] fields, int offset) {
+    for (FieldInfo fi : fields) {
+      if (fi.getStorageOffset() <= offset && offset < fi.getStorageOffset() + fi.getStorageSize()) {
+        return fi.getName();
+      }
+    }
+    throw new JPFErrorException("Field not found for the given offset!");
+  }
+
+  protected String getStaticFieldName (ClassInfo ci, int offset) {
+    return getFieldName(ci.getDeclaredStaticFields(), offset);
+  }
+
+  protected String getInstanceFieldName (ClassInfo ci, int offset) {
+    return getFieldName(ci.getDeclaredInstanceFields(), offset);
+  }
+
+  protected boolean isFieldIgnored (String fn) {
+    return ignoredFields.contains(fn) || fn.toLowerCase().contains("cache");
+  }
+
+  @Override
+  protected void serializeClass (StaticElementInfo sei) {
+    buf.add(sei.getStatus());
+
+    Fields fields = sei.getFields();
+    ClassInfo ci = sei.getClassInfo();
+    FinalBitSet filtered = getStaticFilterMask(ci);
+    FinalBitSet refs = getStaticRefMask(ci);
+
+    int max = ci.getStaticDataSize();
+
+    for (int i = 0; i < max; i++) {
+      if (!filtered.get(i)) {
+        int v = fields.getIntValue(i);
+        String fn = getStaticFieldName(ci, i);
+        if (refs.get(i)) {
+          if (!isFieldIgnored(fn)) {
+            processReference(v);
+          }
+        } else {
+          if (!isFieldIgnored(fn)) {
+            buf.add(v);
+          }
+        }
+      }
+    }
+  }
+
+  public int[] getState (PolDetPhase phase) {
+    phaseOfPolDet = phase;
+    return computeStoringData();
+  }
+}

--- a/src/peers/JPF_PolDetListener.java
+++ b/src/peers/JPF_PolDetListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Pu Yi
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You can find a copy of the GNU General Public License at
+ * <http://www.gnu.org/licenses/>.
+ */
+
+
+import gov.nasa.jpf.annotation.MJI;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.NativePeer;
+import gov.nasa.jpf.vm.serialize.PolDetSerializer;
+import static gov.nasa.jpf.vm.serialize.PolDetSerializer.PolDetPhase;
+import java.util.Arrays;
+
+
+/**
+ * Peer class for PolDetListener, implements methods to get pre-state and post-state for a JUnit test
+ *
+ * @author Pu Yi
+ */
+public class JPF_PolDetListener extends NativePeer {
+
+  static int[] preState;
+  static PolDetSerializer serializer = new PolDetSerializer();
+
+  @MJI
+  public static void capturePreState____V (MJIEnv env, int classRef) {
+    serializer.attach(env.getVM());
+    preState = serializer.getState(PolDetPhase.PRESTATE);
+  }
+
+  @MJI
+  public static boolean compareStates____Z (MJIEnv env, int classRef) {
+    serializer.attach(env.getVM());
+    int[] postState = serializer.getState(PolDetPhase.POSTSTATE);
+    return Arrays.equals(preState, postState);
+  }
+}

--- a/src/tests/PolDet/PolDetExamples.java
+++ b/src/tests/PolDet/PolDetExamples.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2021 Pu Yi
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You can find a copy of the GNU General Public License at
+ * <http://www.gnu.org/licenses/>.
+ */
+
+
+import org.junit.Test;
+import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.After;
+import gov.nasa.jpf.annotation.FilterField;
+import gov.nasa.jpf.vm.Verify;
+
+
+/**
+ *
+ * Example JUnit tests for PolDet@JPF to check
+ *
+ * Run gradle task 'testPolDet' to execute PolDet@JPF on this class
+ *
+ * @author Pu Yi
+ */
+public class PolDetExamples {
+  static int a;
+  static int b;
+  int c = 5;
+  @BeforeClass
+  public static void initialize() {
+    a = 0;
+    b = 1;
+  }
+  @Test
+  public void t1() {
+  }
+  @Test
+  public void t2() {
+    a = 4;
+  }
+  @Test
+  public void t3() {
+    // change instance field, not pollution
+    c = 2;
+  }
+  @Test
+  public void t4() {
+    System.out.println(ClassA.string);
+  }
+  @Test
+  public void t5() {
+    String s = "bar";
+    new ClassB().setString(s);
+  }
+  @Test
+  public void t6() {
+    // false negative due to common-root isomorphism
+    ClassD d = new ClassD();
+  }
+  @Test
+  public void t7() {
+    // change the object cache, should not be considered as pollution
+    try {
+      Class c = Class.forName("gov.nasa.jpf.BoxObjectCaches");
+      java.lang.reflect.Field f = c.getDeclaredField("byteCache");
+      f.setAccessible(true);
+      Byte[] b = new Byte[5];
+      f.set(null, b);
+    } catch(Exception e) {
+      System.out.println(e);
+    }
+  }
+}
+
+class ClassA {
+  static String string = "foo";
+  static void setString(String s) {
+    string = s;
+  }
+}
+
+class ClassB {
+  void setString(String s) {
+    ClassA.setString(s);
+  }
+}
+
+class ClassC {
+  static int instanceCount = 0;
+  ClassC() {
+    instanceCount++;
+  }
+}
+
+class ClassD {
+  ClassC c;
+  ClassD() {
+    c = new ClassC();
+  }
+}

--- a/src/tests/PolDet/PolDetMain.java
+++ b/src/tests/PolDet/PolDetMain.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 Pu Yi
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You can find a copy of the GNU General Public License at
+ * <http://www.gnu.org/licenses/>.
+ */
+
+
+import org.junit.internal.TextListener;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.Result;
+
+
+/**
+ *
+ * entry class for PolDet implementation in JPF. Run gradle task 'runPolDet' to execute PolDet@JPF.
+ *
+ * Two parameters are required for the gradle task 'runPolDet':
+ * 1. testClasspath: the classpath to the test class
+ * 2. testClass: the fully qualified name of the test class
+ *
+ * given the fully qualified names of JUnit test classes, output the tests that pollute the shared state
+ *
+ * @author Pu Yi
+ */
+public class PolDetMain {
+
+  public static void main (String... args) throws Exception {
+    if ("".equals(args[0])) return;
+    JUnitCore core = new JUnitCore();
+    core.addListener(new PolDetListener());
+    core.addListener(new TextListener(System.out));
+    for (String testClass : args) {
+      core.run(Class.forName(testClass));
+    }
+  }
+}
+
+class PolDetListener extends RunListener {
+  public native static void capturePreState();
+  public native static boolean compareStates();
+
+  int polluterCount;
+
+  public void testRunStarted (Description description) {
+    polluterCount = 0;
+  }
+
+  public void testStarted (Description description) {
+    capturePreState();
+  }
+
+  public void testFinished (Description description) {
+    if (!compareStates()) {
+      System.out.println(description.getClassName() + "#" + description.getMethodName() + " pollutes the state");
+      polluterCount++;
+    }
+  }
+
+  public void testRunFinished (Result result) {
+    System.out.println("Number of tests checked: " + result.getRunCount());
+    System.out.println("Number of tests that pollute the state: " + polluterCount);
+  }
+}


### PR DESCRIPTION
# PolDet@JPF

PolDet (Pollution Detection) implementation using Java PathFinder. This tool detects JUnit tests that pollute the shared program state. For more information, read our paper accepted by JPF workshop 2021: https://y553546436.github.io/files/jpf_sen.pdf .

## PolDet implementation 

PolDet implementation is in the following three files:

1. src/tests/PolDet/PolDetMain.java
2. src/peers/JPF_PolDetListener.java
3. src/main/gov/nasa/jpf/vm/serialize/PolDetSerializer.java

File PolDetMain.java contains class PolDetMain, the entry class to run PolDet. It also contains PolDetListener class, a specialized JUnit listener to call our code before and after the test. File JPF_PolDetListener.java contains the peer class for PolDetListener class. File PolDetSerializer.java contains a specialized JPF state serializer which ignores certain irrelevant parts of the state when serializing.

7 example JUnit test methods are in src/tests/PolDet/PolDetExamples.java, which can be used to check the functionality of PolDet.

Note that no existing code is changed in jpf-core, so it is unlikely that some existing functionality breaks with the changes.

## Usage

To run PolDet@JPF:

```
./gradlew runPolDet -PtestClasspath=$CLASSPATH -PtestClass=$CLASSNAME
```
where `$CLASSPATH` is the classpath to the test class, and `$CLASSNAME` is the fully qualified test class name.

To test PolDet@JPF on the 7 example tests in src/tests/PolDet/PolDetExamples.java, run
```
./gradlew testPolDet
```

### Get the classpath for a Maven project

If you want to run a test class in a Maven project, you can get the classpath containing the class and its dependencies with the following command:

```
cd $MODULE
CP=$(pwd)/target/classes:$(pwd)/target/test-classes:$(mvn dependency:build-classpath | grep -A1 "\[INFO\] Dependencies classpath:" | tail -1)
```

For a single-module maven project, `MODULE` is the project directory. For a multi-project maven directory, ​`MODULE` is the specific module directory containing the test class. For example, project httpcomponents-client (https://github.com/apache/httpcomponents-client) contains sub-modules like httpclient5 and httpclient5-cache. If your test class is inside httpclient5 module, you should run the `CP=...` command in directory `httpcomponents-client/httpclient5` to get the correct classpath. To test your classpath, you can run PolDet@JPF on test class `org.apache.hc.client5.http.async.methods.SimpleBasicHttpRequests` with the script above. There should be one test method named `testCreateMethodUriString` detected as a polluter test.