### PR TITLE
Save properties in VM

### DIFF
--- a/src/classes/java/lang/System.java
+++ b/src/classes/java/lang/System.java
@@ -61,6 +61,7 @@ public class System {
         properties.put(kv[i], kv[i+1]);
       }
     }
+    sun.misc.VM.saveAndRemoveProperties(properties);
 
     // this is the Java 6 sun.misc.SharedSecrets backdoor mechanism which I
     // would have prefered not to learn about. It's a mess WRT Java 1.5 / 6 compatibility

--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -2552,6 +2552,7 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
 
       ci.classLoader = cl;
       ci.interfaces = new HashSet<ClassInfo>();
+      ci.allInterfaces = null;
       ci.resolveClass();
 
       ci.id = -1;


### PR DESCRIPTION
This fixes #325, as the testSimpleReadbackOk runs correctly in Java 8 after this patch.

Note that this is not the complete implementation in initializeSystemClass(), but the minimum of what is required to fix this test case.