### PR TITLE
Fix a bug in private method dispatch (#348)

### DIFF
--- a/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
@@ -275,4 +275,26 @@ public class MethodTest extends TestMethodBase {
       assertEquals(42, new Child().foo());
     }
   }
+
+
+  static int sameNameMethodCanary = 0;
+  private void sameNameMethod() {
+    sameNameMethodCanary++;
+    assertEquals(sameNameMethodCanary, 1);
+    new PrivateMethodDispatchCallee().sameNameMethod();
+  }
+
+  static class PrivateMethodDispatchCallee {
+    public void sameNameMethod() {
+      sameNameMethodCanary--;
+    }
+  }
+
+  @Test
+  public void testPrivateMethodDispatch() {
+    if (verifyNoPropertyViolation()) {
+      sameNameMethod();
+    }
+  }
+
 }


### PR DESCRIPTION
This should fix #348 
This bug only exists on Java 11 so only in `java-10-gradle` branch. A unit test is also provided.

I have run `./gradlew clean check` locally and find no regressions. (There are still 13 test failures as JPF doesn't fully support Java 11 yet.)