### PR TITLE
Fix string concat bug of not calling correct toString() method

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -468,4 +468,24 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
   }
 
   native public static void checkBoundsOffCount(int offset, int count, int length);
+
+
+  // This private method is NOT part of the String API.
+  // It is meant to be used ONLY in FunctionObjectFactory
+  // for invokedynamic's String concatenation.
+  //
+  // Any further modifications of this function MUST NOT use any
+  // string concatenation operations in it, otherwise it can
+  // trap into infinite recursion.
+  private static String generateStringByConcatenatingArgs(Object[] args) {
+    // We use StringBuilder just like what OpenJDK does before JDK 9.
+    // More importantly, unlike StringBuffer, StringBuilder
+    // doesn't involves any synchronization operations, which prevent JPF
+    // from generating unnecessary state transitions.
+    StringBuilder builder = new StringBuilder();
+    for (Object arg : args) {
+      builder.append(arg);
+    }
+    return builder.toString();
+  }
 }

--- a/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
@@ -128,6 +128,16 @@ public class INVOKEDYNAMIC extends Instruction {
     frame.pop(freeVariableSize);
     frame.pushRef(funcObjRef);
     
-    return getNext(ti);
+    if (funcObjRef == MJIEnv.NULL) {
+      // In case of string concat, we return a null ref as a dummy arg.
+      // It is here only to be popped at the helper function's
+      // (java.lang.String.generateStringByConcatenatingArgs) return.
+      // We continue execution from the newly created stack frame (in the helper function).
+      return ti.getPC();
+    } else {
+      // In other cases (for lambda expr), this return value shouldn't be null.
+      // We continue execution from the following bytecode.
+      return getNext(ti);
+    }
   }
 }

--- a/src/tests/java11/StringConcatenationTest.java
+++ b/src/tests/java11/StringConcatenationTest.java
@@ -36,6 +36,17 @@ public class StringConcatenationTest extends TestJPF {
     }
 
     @Test
+    public void testStringConcatenationWith_null() {
+        if (verifyNoPropertyViolation()) {
+            String tomorrow = "tomorrow";
+            Object unknown = null;
+            String actual = "The weather will be " + unknown + " " + tomorrow + ".";
+            String expected = "The weather will be null tomorrow.";
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
     public void testStringConcatenationWithEmptyString() {
         if (verifyNoPropertyViolation()) {
             String[] strings = {"The", "weather", "will", "be", "sunny", "tomorrow"};


### PR DESCRIPTION
This PR should fix the following two failing string concat tests, which are parts of #274.
```
java11.StringConcatenationTest::testStringConcatenationWith_toString
java11.StringConcatenationTest::testStringConcatenationWith_toStringNested
```
I have tested locally and find that it fixes these two failing tests with no more regressions (11 failing tests left now).
## Problem Analysis
From JDK 9, the default implementation of string concat is changed to use `invokedynamic`. In OpenJDK's implementation, during the execution of `invokedynamic`, it generates bytecode dynamically to convert the args of string concat to the right data type (for example, call `toString()` of the reference type) and concatenate them.

In the current implementation of JPF, during using `invokedynamic` to do string concat, it doesn't call the `toString()` method of reference types in the string concat args. It could cause the result string to be wrong in a case like `"Info: " + Person` where `Person` has a user-defined `toString()` method.

## Challenges
1. Handwriting bytecode is hard, but importing libraries like `asm` is too heavy.
2. JPF is a model checking JVM saving program states; generating too much or too complex code could bring unnecessary runtime burdens.

## Basic Idea of This Patch
In the case of string concat, `invokedynamic` works like a function that receives variable-length args and returns a reference to a concatenated String. Similarly, this patch implements the following:
1. During the execution of `invokedynamic` itself, the args of string concat are collected and put into a reference array, a new stack frame is created to call the helper function `java.lang.String.generateStringByConcatenatingArgs()`.
2. Then, the execution continues from the helper function. It uses `StringBuilder` to concatenate the args of `invokedynamic` and return a reference to the concatenated String.

## Limitations
It cannot handle cases where string concat args have special string literals containing `'\u0001'` or `'\u0002'`. In these cases, BSM could have more than one static argument (please refer to [this SO answer](https://stackoverflow.com/a/65183722)). Even JPF's class file parser has not yet supported this case. So classfiles containing these cases can make JPF fail at the class loading phase. Fortunately, these are rare cases. I'd like to add support to them later.