### PR TITLE
Fix the bug in the test case for Runtime.availableProcessors()

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/lang/RuntimeTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/RuntimeTest.java
@@ -41,7 +41,17 @@ public class RuntimeTest extends TestJPF {
     }
 
     if (!isJPFRun()) {
-      if (Verify.getCounter(0) != 2) {
+      // During initialization, JPF initializes some system classes,
+      // including java.lang.System.
+      //
+      // Since OpenJDK 9, java.lang.System's class initialization
+      // will indirectly triggers class initialization of
+      // j.u.c.ConcurrentHashMap, which contains a call to
+      // Runtime.availableProcessors().
+      //
+      // Consequently, during the whole execution of this test case, there are
+      // two calls to availableProcessors(), thus generating (2 * 2) states.
+      if (Verify.getCounter(0) != 4) {
         fail("wrong number of backtracks: " + Verify.getCounter(0));
       }
     }


### PR DESCRIPTION
This PR should fix the following failing test, which is a part of #274.
```
gov.nasa.jpf.test.java.lang.RuntimeTest::testAvailableProcessors
```
I have tested locally and found that it fixes this test case with no more regressions (10 failing tests left now).

## Problem Analysis
This may not be a bug of JPF, but a bug of the unit test.

In the execution of this test case, **`Runtime.availableProcessors()` is called twice, thus generating `2*2=4` states instead of the asserted 2**. Except for an explicit invocation in the test case, JPF's initialization also invokes it once. The following content explains how this happens.

In the initialization phase of JPF, it loads and initializes some system classes, including `java.lang.System`. **For JPF running on OpenJDK 11**, the static initializer `<clinit>` of `java.lang.System` indirectly calls `Runtime.availableProcessors()` in the following brief code path.

1. JPF calls `<clinit>` of `java.lang.System` (JPF version)

https://github.com/javapathfinder/jpf-core/blob/3408119d115e539956a3d920e22e856e05bb9d23/src/main/gov/nasa/jpf/vm/VM.java#L444-L447

2. `java.lang.System`'s (JPF version) `<clinit>` calls `<init>` of `java.util.Properties` (OpenJDK 11 version)

https://github.com/javapathfinder/jpf-core/blob/3408119d115e539956a3d920e22e856e05bb9d23/src/classes/java/lang/System.java#L48-L54

3. `java.util.Properties`'s (OpenJDK 11 version) `<init>` call `java.util.ConcurrentHashMap`'s (OpenJDK 11 version) `<init>`, which triggers its loading and initialization, thus calling its `<clinit>`

https://github.com/openjdk/jdk11u/blob/31396660db3eae3977bbbf8b978b581dfd941d2d/src/java.base/share/classes/java/util/Properties.java#L203C9-L212
```java
    private Properties(Properties defaults, int initialCapacity) {
        // use package-private constructor to
        // initialize unused fields with dummy values
        super((Void) null);
        map = new ConcurrentHashMap<>(initialCapacity);
        this.defaults = defaults;

        // Ensure writes can't be reordered
        UNSAFE.storeFence();
    }
```

4. `j.u.c.ConcurrentHashMap`'s (OpenJDK 11 version) `<clinit>` calls `Runtime.availableProcessors()`

https://github.com/openjdk/jdk11u/blob/31396660db3eae3977bbbf8b978b581dfd941d2d/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java#L596C14-L597
```java
    /** Number of CPUS, to place bounds on some sizings */
    static final int NCPU = Runtime.getRuntime().availableProcessors();
```

## Discussions
> Why this test passes on `master` branch (on JDK 8).

We can see that using `j.u.c.ConcurrentHashMap` in `j.u.Properties` is a change made in JDK 9 (in the commit https://github.com/openjdk/jdk9/commit/0260528ef92c4cdfd14198639b78e8e6d0c81613). So, execution of this test case on OpenJDK 8 will only call `Runtime.availableProcessors()` once thus generating 2 states.