### PR TITLE
Fix a not-throwing-exception bug in Class.newInstance

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -225,7 +225,15 @@ public class JPF_java_lang_Class extends NativePeer {
     DirectCallStackFrame frame = ti.getReturnedDirectCall();
     
     ClassInfo ci = env.getReferredClassInfo(robj);   // what are we
-    MethodInfo miCtor = ci.getMethod("<init>()V", true); // note there always is one since something needs to call Object()
+    MethodInfo miCtor = ci.getMethod("<init>()V", false);
+
+    // According to Java SE 11 API Specification,
+    // If "the class has no nullary constructor", this method
+    // should throw java.lang.InstantiationException
+    if (miCtor == null) {
+      env.throwException("java.lang.InstantiationException", ci.getName());
+      return MJIEnv.NULL;
+    }
 
     if (frame == null){ // first time around
       if(ci.isAbstract()){ // not allowed to instantiate

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -237,8 +237,23 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
       clazz.getDeclaredConstructor().newInstance();
     }
   }
-  
-  
+
+  static class NoDefaultCtor {
+
+    int i;
+
+    public NoDefaultCtor(int i) {
+      this.i = i;
+    }
+  }
+
+  @Test
+  public void testNoDefaultConstructor() throws ReflectiveOperationException {
+    if (verifyUnhandledException("java.lang.InstantiationException")) {
+      NoDefaultCtor.class.newInstance();
+    }
+  }
+
   @Test 
   public void testIsAssignableFrom () {
     if (verifyNoPropertyViolation()) {


### PR DESCRIPTION
This PR should fix a bug that, in some cases, execution should throw an exception, but it doesn't on JPF. And a test case for this bug is added. This patch may also apply to `master` branch (on OpenJDK 8).

I have tested locally on `java-10-gradle` branch; this fix brings no regressions (still, 11 failing tests left). 

## Reproduction
According to Java API doc for [java.lang.Class.newInstance()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance()), the following code snippet should throw `InstantiationException`. (It falls into the category of "the class has no nullary constructor"). But it doesn't throw any exception on JPF.
```
public class Main {

  static class C {
    int i;

    public C(int i) {
      this.i = i;
    }
  }

  public static void main (String[] args) throws Exception {
    C.class.newInstance();
  }
}
```

## Problem Analysis
JPF doesn't check this case and does the wrong dispatch in the `java.lang.Class.newInstance` code.

https://github.com/javapathfinder/jpf-core/blob/3408119d115e539956a3d920e22e856e05bb9d23/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java#L222-L229

## Basic Idea of This Fix
Just handle this case in the implementation of `java.lang.Class.newInstance`.