### PR TITLE
Fix a not-throwing-exception bug in Class.newInstance, a backport of PR #353

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -224,7 +224,15 @@ public class JPF_java_lang_Class extends NativePeer {
     DirectCallStackFrame frame = ti.getReturnedDirectCall();
     
     ClassInfo ci = env.getReferredClassInfo(robj);   // what are we
-    MethodInfo miCtor = ci.getMethod("<init>()V", true); // note there always is one since something needs to call Object()
+    MethodInfo miCtor = ci.getMethod("<init>()V", false);
+
+    // According to Java SE 8 API Specification,
+    // If 'the class has no nullary constructor', this method
+    // should throws java.lang.InstantiationException
+    if (miCtor == null) {
+      env.throwException("java.lang.InstantiationException", ci.getName());
+      return MJIEnv.NULL;
+    }
 
     if (frame == null){ // first time around
       if(ci.isAbstract()){ // not allowed to instantiate

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -195,7 +195,22 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
       clazz.newInstance();
     }
   }
-  
+
+  static class NoDefaultCtor {
+
+    int i;
+
+    public NoDefaultCtor(int i) {
+      this.i = i;
+    }
+  }
+
+  @Test
+  public void testNoDefaultConstructor() throws ReflectiveOperationException {
+    if (verifyUnhandledException("java.lang.InstantiationException")) {
+      NoDefaultCtor.class.newInstance();
+    }
+  }
   
   @Test 
   public void testIsAssignableFrom () {

--- a/src/tests/gov/nasa/jpf/test/vm/basic/RecursiveClinitTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/RecursiveClinitTest.java
@@ -64,9 +64,9 @@ public class RecursiveClinitTest extends TestJPF {
   @Test
   public void testNewInstance (){
     if (verifyNoPropertyViolation()) {
-      System.out.println("main now calling Derived.class.newInstance()");
+      System.out.println("main now calling Derived.class.getConstructor(int.class).newInstance(1)");
       try {
-        Derived.class.newInstance();
+        Derived.class.getConstructor(int.class).newInstance(1);
       } catch (Throwable t) {
         fail("instantiation failed with " + t);
       }


### PR DESCRIPTION
This is a backport of #353 on `master` branch. This patch is a little bit different from that one because of some file differences.