### PR TITLE
Fix the bug of incorrect mapping from bootstrap method index to invokedynamic CP index

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/ClassFile.java
+++ b/src/main/gov/nasa/jpf/jvm/ClassFile.java
@@ -96,9 +96,11 @@ public class ClassFile extends BinaryClassSource {
   // We store this info because we need to get the call site descriptor of
   // an invokedynamic when its corresponding BSM is parsed later.
   //
-  // For each invokedynamic instruction, there is a bootstrap method in the class file (not 1-1).
+  // For each invokedynamic instruction, there is a bootstrap method in the class file, while
+  // multiple invokedynamic instructions may share one bootstrap method (an n-1 mapping).
   // And there is also a CONSTANT_InvokeDynamic_info structure in the constant pool
-  // of the class file for each invokedynamic (not 1-1). It is roughly in the following form:
+  // of the class file for each invokedynamic, while multiple invokedynamic instructions may
+  // share one such info (an n-1 mapping). The structure is roughly in the following form:
   //              (bootstrap_method_index, call_site_descriptor)
   // This information can be got when we parse the invokedynamic instruction.
   // We also need it when we later parse bootstrap method because we need the

--- a/src/main/gov/nasa/jpf/jvm/ClassFile.java
+++ b/src/main/gov/nasa/jpf/jvm/ClassFile.java
@@ -95,6 +95,19 @@ public class ClassFile extends BinaryClassSource {
   // Map index of bootstrap method to constant pool index of invokedynamic.
   // We store this info because we need to get the call site descriptor of
   // an invokedynamic when its corresponding BSM is parsed later.
+  //
+  // For each invokedynamic instruction, there is a bootstrap method in the class file (not 1-1).
+  // And there is also a CONSTANT_InvokeDynamic_info structure in the constant pool
+  // of the class file for each invokedynamic (not 1-1). It is roughly in the following form:
+  //              (bootstrap_method_index, call_site_descriptor)
+  // This information can be got when we parse the invokedynamic instruction.
+  // We also need it when we later parse bootstrap method because we need the
+  // call site descriptor. Thus, a Map is used to store the mapping of:
+  // bootstrap method index => constant pool index of CONSTANT_InvokeDynamic_info structure
+  //
+  // Later, when we parse bootstrap method, we can get constant pool index of
+  // that structure and use callSiteDescriptor() function to parse call site descriptor
+  // from that structure.
   Map<Integer, Integer> bsmIdxToIndyCpIdx= new HashMap<>();
 
   //--- ctors

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -20,6 +20,7 @@ package java8;
 import gov.nasa.jpf.util.test.TestJPF;
 
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -307,5 +308,13 @@ public class LambdaTest extends TestJPF{
 
   private Supplier<String> getStringProvider(String object) {
     return () -> object == null ? "It was null" : object;
+  }
+
+  @Test
+  public void testLoadClassWithManyBootstrapMethods() {
+    if(verifyNoPropertyViolation()) {
+      // java.util.stream.Collectors contains many bootstrap methods
+      Collectors.toSet();
+    }
   }
 }

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -311,7 +311,7 @@ public class LambdaTest extends TestJPF{
   }
 
   @Test
-  public void testLoadClassWithManyBootstrapMethods() {
+  public void testLoadingClassWithManyBootstrapMethods() {
     if(verifyNoPropertyViolation()) {
       // java.util.stream.Collectors contains many bootstrap methods
       Collectors.toSet();


### PR DESCRIPTION
This patch should fix a subtle bug that causes loading of a class with many BSMs to fail. This is also a preliminary work for supporting `StackWalker` APIs. It adds a unit test and should bring no regressions (still 7 test failures left).

## Problem
### 1. Wrong hard-coding size
`invokeDynamicIndex` is used to map bootstrap method to `invokedynamic` in CP
https://github.com/javapathfinder/jpf-core/blob/b94d1aed34391b6722ff4f4d686a9f471cec6070/src/main/gov/nasa/jpf/jvm/ClassFile.java#L95-L97

Its size should have been equal to the number of BSMs. But it is initialized to a constant value.
https://github.com/javapathfinder/jpf-core/blob/b94d1aed34391b6722ff4f4d686a9f471cec6070/src/main/gov/nasa/jpf/jvm/ClassFile.java#L106-L108

This hard-coding size bug will surely cause OOB exception during JPF’s loading a class containing many BSMs (eg, `java.util.stream.Collectors`).

### 2. Wrong mapping from BSM index to `invokedynamic` CP index
We need this map because we need to get callsite descriptor of a BSM’s `invokedynamic` when we parse the BSM:
https://github.com/javapathfinder/jpf-core/blob/b94d1aed34391b6722ff4f4d686a9f471cec6070/src/main/gov/nasa/jpf/jvm/ClassFile.java#L1512-L1516

The map is filled in the following code:
https://github.com/javapathfinder/jpf-core/blob/b94d1aed34391b6722ff4f4d686a9f471cec6070/src/main/gov/nasa/jpf/jvm/ClassFile.java#L2711-L2714

The above two code snippets (for reading and storing) makes the implicit assumption that `invokedynamic` instruction and BSM have one-to-one mapping and BSM has the same order as the appearing order of `invokedynamic` instruction in the classfile. However, this is not always true. For example, the classfile of the following source code violates the assumption.
```java
import java.util.function.Supplier;
import java.util.function.Consumer;

public class BSM {
  void test() {
    Supplier s1 = BSM::new;
    Supplier s2 = BSM::new;
    Consumer c = x -> { };
  }
}
```
And its classfile:
```class

Classfile /tmp/BSM.class
  Last modified Jun 16, 2023; size 931 bytes
  MD5 checksum 7704356024d3601f8fec2a5525923ae1
  Compiled from "BSM.java"
public class BSM
  minor version: 0
  major version: 55
  flags: (0x0021) ACC_PUBLIC, ACC_SUPER
  this_class: #4                          // BSM
  super_class: #5                         // java/lang/Object
  interfaces: 0, fields: 0, methods: 3, attributes: 3
Constant pool:
   #1 = Methodref          #5.#15         // java/lang/Object."<init>":()V
   #2 = InvokeDynamic      #0:#20         // #0:get:()Ljava/util/function/Supplier;
   #3 = InvokeDynamic      #1:#23         // #1:accept:()Ljava/util/function/Consumer;
[…]
  void test();
    descriptor: ()V
    flags: (0x0000)
    Code:
      stack=1, locals=4, args_size=1
         0: invokedynamic #2,  0              // InvokeDynamic #0:get:()Ljava/util/function/Supplier;
         5: astore_1
         6: invokedynamic #2,  0              // InvokeDynamic #0:get:()Ljava/util/function/Supplier;
        11: astore_2
        12: invokedynamic #3,  0              // InvokeDynamic #1:accept:()Ljava/util/function/Consumer;
        17: astore_3
        18: return
      LineNumberTable:
        line 6: 0
        line 7: 6
        line 8: 12
        line 9: 18
[…]
SourceFile: "BSM.java"
InnerClasses:
  public static final #40= #39 of #43;    // Lookup=class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles
BootstrapMethods:
  0: #17 REF_invokeStatic java/lang/invoke/LambdaMetafactory.metafactory:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;
    Method arguments:
      #18 ()Ljava/lang/Object;
      #19 REF_newInvokeSpecial BSM."<init>":()V
      #18 ()Ljava/lang/Object;
  1: #17 REF_invokeStatic java/lang/invoke/LambdaMetafactory.metafactory:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;
    Method arguments:
      #21 (Ljava/lang/Object;)V
      #22 REF_invokeStatic BSM.lambda$test$0:(Ljava/lang/Object;)V
      #21 (Ljava/lang/Object;)V
```
Luckily, this wrong mapping doesn’t affect the correctness of JPF, because the descriptor obtained here is in fact not used in the following execution. But this is also a bug and should be fixed.

## Solution
Use a growable data structure (`Map`) and fix the mapping information.