### PR TITLE
Fix the bytecode behavior implementation of REF_newInvokeSpecial method handle

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -786,6 +786,8 @@ public class JVMClassInfo extends ClassInfo {
     int modifiers = fiMethod.getModifiers() & (~Modifier.ABSTRACT);
     int nLocals = fiMethod.getArgumentsSize();
     int nOperands = this.nInstanceFields + nLocals;
+    // If it is a REF_newInvokeSpecial method handle,
+    // we need one more stack slot to store the dupped object reference
     if (bootstrapMethod.getLambdaRefKind() == ClassFile.REF_NEW_INVOKESPECIAL) {
       nOperands += 1;
     }
@@ -989,7 +991,9 @@ public class JVMClassInfo extends ClassInfo {
     
     String calleeClass = miCallee.getClassName(); 
     
-    // adding the bytecode instruction to invoke lambda method
+    // Add the bytecode instruction to invoke lambda method.
+    // Implement bytecode behaviors for method handles.
+    // See https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-5.html#jvms-5.4.3.5
     switch (bootstrapMethod.getLambdaRefKind()) {
     case ClassFile.REF_INVOKESTATIC:
       cb.invokestatic(calleeClass, calleeName, calleeSig);

--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -786,6 +786,9 @@ public class JVMClassInfo extends ClassInfo {
     int modifiers = fiMethod.getModifiers() & (~Modifier.ABSTRACT);
     int nLocals = fiMethod.getArgumentsSize();
     int nOperands = this.nInstanceFields + nLocals;
+    if (bootstrapMethod.getLambdaRefKind() == ClassFile.REF_NEW_INVOKESPECIAL) {
+      nOperands += 1;
+    }
 
     MethodInfo mi = new MethodInfo(fiMethod.getName(), fiMethod.getSignature(), modifiers, nLocals, nOperands);
     mi.linkToClass(this);
@@ -999,6 +1002,7 @@ public class JVMClassInfo extends ClassInfo {
       break;
     case ClassFile.REF_NEW_INVOKESPECIAL:
       cb.new_(calleeClass);
+      cb.dup();
       cb.invokespecial(calleeClass, calleeName, calleeSig);
       break;
     case ClassFile.REF_INVOKESPECIAL:

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -45,7 +45,15 @@ public class LambdaTest extends TestJPF{
       (new Thread(r)).start();
     }
   }
-  
+
+  @Test
+  public void testNewSpecialMethodHandle() {
+    if(verifyNoPropertyViolation()) {
+      Supplier s = LambdaTest::new;
+      assertTrue(s.get().getClass() == this.getClass());
+    }
+  }
+
   public interface FI1 {
     void sam();
   }


### PR DESCRIPTION
This patch should fix the bug in implementing bytecode behavior for method handle of kind `REF_newInvokeSpecial`. It is also a preliminary work for supporting `StackWalker` APIs. It adds a unit test and should bring no regressions (still 7 test failures left).

According to [specification](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-5.html#jvms-5.4.3.5), current implementation loses a `dup` bytecode thus returning the wrong value.
