### PR TITLE
Update unit test `testStackWalkerInCaseOfChoiceGenerator` to speed it up

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/lang/StackWalkerTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StackWalkerTest.java
@@ -102,17 +102,22 @@ public class StackWalkerTest extends TestJPF {
 
   @Test
   public void testStackWalkerInCaseOfChoiceGenerator() {
+    Object lock = this;
     if (verifyNoPropertyViolation()){
       Thread t1 = new Thread() {
         @Override
         public void run() {
-          callIt();
+          synchronized (lock) {
+            callIt();
+          }
         }
       };
       Thread t2 = new Thread() {
         @Override
         public void run() {
-          callIt();
+          synchronized (lock) {
+            callIt();
+          }
         }
       };
       t1.start();


### PR DESCRIPTION
This should fix #361. It adds a lock to eliminate unnecessary state transitions to speed up the unit test `testStackWalkerInCaseOfChoiceGenerator`.