### PR TITLE
Bytecode for REF_newInvokeSpecial: load new object as first argument

### DIFF
--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -19,6 +19,7 @@ package java8;
 
 import gov.nasa.jpf.util.test.TestJPF;
 
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -52,6 +53,28 @@ public class LambdaTest extends TestJPF{
     if(verifyNoPropertyViolation()) {
       Supplier s = LambdaTest::new;
       assertTrue(s.get().getClass() == this.getClass());
+    }
+  }
+
+  public static class Concatenator {
+    private final String s1, s2;
+
+    public Concatenator(String s1, String s2) {
+      this.s1 = s1;
+      this.s2 = s2;
+    }
+
+    public String getConcatenation() {
+      return s1 + s2;
+    }
+  }
+
+  @Test
+  public void testNewSpecialMethodHandleWithArguments() {
+    if(verifyNoPropertyViolation()) {
+      BiFunction<String, String, Concatenator> cons = Concatenator::new;
+      Concatenator c = cons.apply("foo", "bar");
+      assertTrue(c.getConcatenation().equals("foobar"));
     }
   }
 


### PR DESCRIPTION
A constructor takes the new object as its _first_ argument. This patch modifies bytecode generation for `REF_NEW_INVOKESPECIAL` to load the new object _before_ any other arguments to a constructor.

Submitting pull request to the `java-10-gradle` branch, where the previous fix (#359) is located.