### PR TITLE
Fixed Class.forName for primitive array types

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -188,27 +188,22 @@ public class JPF_java_lang_Class extends NativePeer {
     // class of the method that includes the invocation of Class.forName() 
     ClassInfo cls = mi.getClassInfo();
 
-    String name;
-    // for array type, the component terminal must be resolved
-    if(clsName.charAt(0)=='[') {
-      name = Types.getComponentTerminal(clsName);
-    } else{
-      name = clsName;
-    }
-
-    // make the classloader of the class including the invocation of 
-    // Class.forName() resolve the class with the given name
-    try {
-      cls.resolveReferencedClass(name);
-    } catch(LoadOnJPFRequired lre) {
-      env.repeatInvocation();
-      return MJIEnv.NULL;
+    String typeName = Types.getTypeSignature(clsName, false);
+    if (Types.isReferenceSignature(typeName)) {
+      String t = Types.isArray(typeName) ? Types.getComponentTerminal(typeName) : typeName;
+      try {
+        // make the classloader of the class including the invocation of
+        // Class.forName() resolve the class with the given name
+        cls.resolveReferencedClass(t);
+      } catch (LoadOnJPFRequired lre) {
+        env.repeatInvocation();
+        return MJIEnv.NULL;
+      }
     }
 
     // The class obtained here is the same as the resolved one, except
     // if it represents an array type
-    ClassInfo ci = cls.getClassLoaderInfo().getResolvedClassInfo(clsName);
-
+    ClassInfo ci = cls.getClassLoaderInfo().getResolvedClassInfo(typeName);
     return getClassObject(env, ci);
   }
 

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -75,7 +75,36 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
       }
     }
   }
-  
+
+  private void testClassForNameArray (String className, Class<?> expectedClass) throws ClassNotFoundException {
+    Class<?> clazz = Class.forName(className);
+    assertNotNull(clazz);
+    assertTrue(clazz.isArray());
+    assertEquals(className, clazz.getName());
+    assertSame(expectedClass, clazz);
+  }
+
+  @Test
+  public void testClassForNamePrimitiveArrays () throws ClassNotFoundException {
+    if (verifyNoPropertyViolation()) {
+      testClassForNameArray("[Z", boolean[].class);
+      testClassForNameArray("[I", int[].class);
+      testClassForNameArray("[C", char[].class);
+      testClassForNameArray("[D", double[].class);
+      testClassForNameArray("[F", float[].class);
+      testClassForNameArray("[I", int[].class);
+      testClassForNameArray("[J", long[].class);
+      testClassForNameArray("[S", short[].class);
+    }
+  }
+
+  @Test
+  public void testClassForNameReferenceArray () throws ClassNotFoundException {
+    if (verifyNoPropertyViolation()) {
+      testClassForNameArray("[L" + clsName + ";", ClassTest[].class);
+    }
+  }
+
   @Test
   public void testClassForNameException () throws ClassNotFoundException {
     if (verifyUnhandledException("java.lang.ClassNotFoundException")) {


### PR DESCRIPTION
For example, in the current implementation `Class.forName("[B")` fails with:

> java.lang.ClassNotFoundException: class not found: B

which should be fixed by this patch. The type resolution is based on that of `INSTANCEOF.execute` ([here](https://github.com/javapathfinder/jpf-core/blob/1f99a23a095e89b22b71539dc238ba5d73231a6d/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java#L40) and [here](https://github.com/javapathfinder/jpf-core/blob/1f99a23a095e89b22b71539dc238ba5d73231a6d/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java#L45-L60)).

(Incidentally, `Class.forName("[B")` does work in unit tests because [there exists](https://github.com/javapathfinder/jpf-core/blob/1f99a23a095e89b22b71539dc238ba5d73231a6d/src/tests/TypeNameTest.java#L31) a class named `B` in the unnamed package.)