### PR TITLE
gov.nasa.jpf.vm.Allocation.equals: added missing equality check for the count field

### DIFF
--- a/src/main/gov/nasa/jpf/vm/Allocation.java
+++ b/src/main/gov/nasa/jpf/vm/Allocation.java
@@ -46,7 +46,7 @@ public class Allocation {
       Allocation other = (Allocation)o;
       
       if (other.hash == hash) {
-        if (other.context.equals(context)) {
+        if (other.count == count && other.context.equals(context)) {
           return true;
         }
       }

--- a/src/tests/gov/nasa/jpf/vm/AllocationTest.java
+++ b/src/tests/gov/nasa/jpf/vm/AllocationTest.java
@@ -1,0 +1,17 @@
+package gov.nasa.jpf.vm;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+
+public class AllocationTest extends TestJPF {
+    @Test
+    public void testEqualsHashCollisionSameContext() {
+        AllocationContext ctx = new HashedAllocationContext(-987565178);
+        // Two Allocations with the same context, different counts, but equal hash.
+        Allocation alloc1 = new Allocation(ctx, 40933);
+        Allocation alloc2 = new Allocation(ctx, 64242);
+        assertEquals("the two Allocations should have equal hash", alloc1.hash, alloc2.hash);
+
+        assertFalse(alloc1.equals(alloc2));
+    }
+}


### PR DESCRIPTION
Same as #376, but against the `java-10-gradle` branch.