### PR TITLE
Fix bugs in some calculations related to field sizes of function object created for `invokedynamic` (#378)

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -785,7 +785,15 @@ public class JVMClassInfo extends ClassInfo {
     MethodInfo fiMethod = funcInterface.getInterfaceAbstractMethod();
     int modifiers = fiMethod.getModifiers() & (~Modifier.ABSTRACT);
     int nLocals = fiMethod.getArgumentsSize();
-    int nOperands = this.nInstanceFields + nLocals;
+    // A field may occupy 1 or 2 operand stack slots.
+    // Since all these fields need to be pushed into operand stack,
+    // we need to calculate their total size first.
+    int fieldsSize = 0;
+    for (String fieldTypeName : fieldTypesName) {
+      String typeSig = Types.getTypeSignature(fieldTypeName, false);
+      fieldsSize += Types.getTypeSize(typeSig);
+    }
+    int nOperands = fieldsSize + nLocals;
     // If it is a REF_newInvokeSpecial method handle,
     // we need one more stack slot to store the dupped object reference
     if (bootstrapMethod.getLambdaRefKind() == ClassFile.REF_NEW_INVOKESPECIAL) {

--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -987,8 +987,9 @@ public class JVMClassInfo extends ClassInfo {
     for(int i=0; i<n; i++) {
       cb.aload(0);
       FieldInfo fi = callerCi.getInstanceField(i);
-      
-      cb.getfield(fi.getName(), callerCi.getName(), Types.getTypeSignature(fi.getSignature(), false));
+      // FieldInfo.getSignature() returns the signature for a field, and could
+      // be used to generate a field load instruction with correct type info.
+      cb.getfield(fi.getName(), callerCi.getName(), fi.getSignature());
     }
 
     // Add the bytecode instruction to invoke lambda method.

--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -728,7 +728,10 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
    
    int i = 0;
    for(String type: fieldTypesName) {
-     FieldInfo fi = FieldInfo.create("arg" + i++, type, 0);
+     // FieldInfo.create() need type signature instead of
+     // type name, so we need to convert them first
+     String typeSig = Types.getTypeSignature(type, false);
+     FieldInfo fi = FieldInfo.create("arg" + i++, typeSig, 0);
      fi.linkToClass(this, idx, off);
      iFields[idx++] = fi;
      off += fi.getStorageSize();

--- a/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
+++ b/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
@@ -272,34 +272,41 @@ public class FunctionObjectFactory {
   public void setFuncObjFields(ElementInfo funcObj, BootstrapMethodInfo bmi, String[] freeVarTypeNames, Object[] freeVarValues) {
     Fields fields = funcObj.getFields();
 
+    // Fields.setXXXValue() needs field offset instead of field "index"
+    int fieldOffset = 0;
     for (int i = 0; i < freeVarTypeNames.length; i++) {
       String typeName = freeVarTypeNames[i];
       if (typeName.equals("byte")) {
-        fields.setByteValue(i, (Byte) freeVarValues[i]);
+        fields.setByteValue(fieldOffset, (Byte) freeVarValues[i]);
       } else if (typeName.equals("char")) {
-        fields.setCharValue(i, (Character) freeVarValues[i]);
+        fields.setCharValue(fieldOffset, (Character) freeVarValues[i]);
       } else if (typeName.equals("short")) {
-        fields.setShortValue(i, (Short) freeVarValues[i]);
+        fields.setShortValue(fieldOffset, (Short) freeVarValues[i]);
       } else if (typeName.equals("int")) {
-        fields.setIntValue(i, (Integer) freeVarValues[i]);
+        fields.setIntValue(fieldOffset, (Integer) freeVarValues[i]);
       } else if (typeName.equals("float")) {
-        fields.setFloatValue(i, (Float) freeVarValues[i]);
+        fields.setFloatValue(fieldOffset, (Float) freeVarValues[i]);
       } else if (typeName.equals("long")) {
-        fields.setLongValue(i, (Long) freeVarValues[i]);
+        fields.setLongValue(fieldOffset, (Long) freeVarValues[i]);
       } else if (typeName.equals("double")) {
-        fields.setDoubleValue(i, (Double) freeVarValues[i]);
+        fields.setDoubleValue(fieldOffset, (Double) freeVarValues[i]);
       } else if (typeName.equals("boolean")) {
-        fields.setBooleanValue(i, (Boolean) freeVarValues[i]);
+        fields.setBooleanValue(fieldOffset, (Boolean) freeVarValues[i]);
       } else {
         if (freeVarValues[i] == null) {
-          fields.setReferenceValue(i, MJIEnv.NULL);
+          fields.setReferenceValue(fieldOffset, MJIEnv.NULL);
         } else {
           int val = ((ElementInfo) freeVarValues[i]).getObjectRef() + 1;
           // + 1 because when object is created ( i.e GenericHeap.createObject(...)) the value of objRef is initialized
           // to the NamedField value in ElementInfo. But the value needed here is the value of arrayField which
           // NamedField value +1. This is because both array and object fields are created in GenericHeap.newString().
-          fields.setReferenceValue(i, val);
+          fields.setReferenceValue(fieldOffset, val);
         }
+      }
+      if (typeName.equals("long") || typeName.equals("double")) {
+        fieldOffset += 2;
+      } else {
+        fieldOffset += 1;
       }
     }
   }

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -161,7 +161,33 @@ public class LambdaTest extends TestJPF{
       fi.sam();
     }
   }
-  
+
+  @Test
+  public void testClosureWithLocalsOfDifferentSizes() {
+    if (verifyNoPropertyViolation()) {
+      int i1 = 1;
+      double d2 = 2.0;
+      char c3 = 3;
+      double d4 = 4.0;
+      short s5 = 5;
+      long l6 = 6;
+      long l7 = 7;
+      float f8 = 8.0f;
+
+      FI1 fi = () -> {
+        assertEquals(i1, 1);
+        assertEquals(d2, 2.0);
+        assertEquals(c3, 3);
+        assertEquals(d4, 4.0);
+        assertEquals(s5, 5);
+        assertEquals(l6, 6);
+        assertEquals(l7, 7);
+        assertEquals(f8, 8.0);
+      };
+      fi.sam();
+    }
+  }
+
   static void method(FI1 fi) {
     fi.sam();
   }


### PR DESCRIPTION
This patch should fix #378 and some other bugs in lambda expression's capturing local primitive types of different storage sizes (on branch `java-10-gradle`). A unit test is also added.

I have run `./gradlew clean check` locally and find no regressions.