### PR TITLE
Fix a bug of lambda expression’s capturing wrong reference type local variable (#379)

### DIFF
--- a/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
+++ b/src/main/gov/nasa/jpf/vm/FunctionObjectFactory.java
@@ -296,11 +296,11 @@ public class FunctionObjectFactory {
         if (freeVarValues[i] == null) {
           fields.setReferenceValue(fieldOffset, MJIEnv.NULL);
         } else {
-          int val = ((ElementInfo) freeVarValues[i]).getObjectRef() + 1;
-          // + 1 because when object is created ( i.e GenericHeap.createObject(...)) the value of objRef is initialized
-          // to the NamedField value in ElementInfo. But the value needed here is the value of arrayField which
-          // NamedField value +1. This is because both array and object fields are created in GenericHeap.newString().
-          fields.setReferenceValue(fieldOffset, val);
+          ElementInfo obj = (ElementInfo) freeVarValues[i];
+          if (!obj.getClassInfo().isInstanceOf(freeVarTypeNames[i])) {
+            throw new RuntimeException("Unexpected free variable type for lambda expression");
+          }
+          fields.setReferenceValue(fieldOffset, obj.getObjectRef());
         }
       }
       if (typeName.equals("long") || typeName.equals("double")) {

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -19,6 +19,10 @@ package java8;
 
 import gov.nasa.jpf.util.test.TestJPF;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -183,6 +187,43 @@ public class LambdaTest extends TestJPF{
         assertEquals(l6, 6);
         assertEquals(l7, 7);
         assertEquals(f8, 8.0);
+      };
+      fi.sam();
+    }
+  }
+
+  @Test
+  public void testClosureWithLocalReference() {
+    if (verifyNoPropertyViolation()) {
+      int i1 = 1;
+      double d2 = 2.0;
+      long l3 = 3;
+      String s4 = "abcd";
+
+      FI1 fi = () -> {
+        assertEquals(i1, 1);
+        assertEquals(d2, 2.0);
+        assertEquals(l3, 3);
+        assertEquals(s4, "abcd");
+      };
+      fi.sam();
+    }
+  }
+
+  @Test
+  public void testClosureWithLocalReferenceOfComplexType() {
+    if (verifyNoPropertyViolation()) {
+      double d = 2.0;
+      Set<String> s = new HashSet<>();
+      s.add("abc");
+      List<List<Integer>> l = new ArrayList<>();
+      l.add(new ArrayList<>());
+      FI1 fi = () -> {
+        assertEquals(d, 2.0);
+        assertEquals(s.getClass().getName(), HashSet.class.getName());
+        assertTrue(s.contains("abc"));
+        assertEquals(l.getClass().getName(), ArrayList.class.getName());
+        assertEquals(l.size(), 1);
       };
       fi.sam();
     }

--- a/src/tests/java8/LambdaTest.java
+++ b/src/tests/java8/LambdaTest.java
@@ -218,6 +218,7 @@ public class LambdaTest extends TestJPF{
       s.add("abc");
       List<List<Integer>> l = new ArrayList<>();
       l.add(new ArrayList<>());
+
       FI1 fi = () -> {
         assertEquals(d, 2.0);
         assertEquals(s.getClass().getName(), HashSet.class.getName());


### PR DESCRIPTION
This patch should fix #379. A local run of `./gradlew clean check` shows no regression.