### PR TITLE
Class.getField should return only public fields

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -609,7 +609,7 @@ public class JPF_java_lang_Class extends NativePeer {
     return aref;
   }
     
-  int getField (MJIEnv env, int clsRef, int nameRef, boolean isRecursiveLookup) {    
+  int getField (MJIEnv env, int clsRef, int nameRef, boolean isRecursiveLookup, boolean publicOnly) {
     ClassInfo ci = env.getReferredClassInfo( clsRef);
     String fname = env.getStringObject(nameRef);
     FieldInfo fi = null;
@@ -626,7 +626,7 @@ public class JPF_java_lang_Class extends NativePeer {
         }
     }
     
-    if (fi == null) {      
+    if (fi == null || (publicOnly && !fi.isPublic())) {
       env.throwException("java.lang.NoSuchFieldException", fname);
       return MJIEnv.NULL;
       
@@ -644,12 +644,16 @@ public class JPF_java_lang_Class extends NativePeer {
   
   @MJI
   public int getDeclaredField__Ljava_lang_String_2__Ljava_lang_reflect_Field_2 (MJIEnv env, int clsRef, int nameRef) {
-    return getField(env,clsRef,nameRef, false);
+    // From Java 8 doc: "Returns a Field object that reflects the specified declared field of the class or interface
+    // represented by this Class object." -- Not confined to public fields!
+    return getField(env,clsRef,nameRef, /* isRecursiveLookup = */ false, /* publicOnly = */ false);
   }  
  
   @MJI
   public int getField__Ljava_lang_String_2__Ljava_lang_reflect_Field_2 (MJIEnv env, int clsRef, int nameRef) {
-    return getField(env,clsRef,nameRef, true);    
+    // From Java 8 doc (emphasis added): "Returns a Field object that reflects the specified **public** member field of
+    // the class or interface represented by this Class object."
+    return getField(env,clsRef,nameRef, /* isRecursiveLookup = */ true, /* publicOnly = */ true);
   }
 
   @MJI

--- a/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
@@ -99,7 +99,7 @@ public class FieldTest extends TestJPF {
   }
   
   public static class ShortField {
-    short f;
+    public short f;
   }
 
   @Test

--- a/src/tests/gov/nasa/jpf/test/mc/basic/FinalBreakTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/basic/FinalBreakTest.java
@@ -34,7 +34,7 @@ public class FinalBreakTest extends TestJPF {
   static class InstanceFinal {
     static InstanceFinal global;
     
-    final int a;
+    public final int a;
     final int b;
     
     InstanceFinal (){
@@ -137,7 +137,7 @@ public class FinalBreakTest extends TestJPF {
   final static Object o2 = new Object();
   
   static class StaticFinal {
-    final static Object a = o1;
+    public final static Object a = o1;
     final static Object b = o1;
   }
 

--- a/src/tests/gov/nasa/jpf/test/vm/reflection/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/reflection/FieldTest.java
@@ -25,13 +25,13 @@ import org.junit.Test;
 
 public class FieldTest extends TestJPF {
 
-  int instInt = 42;
-  double instDouble = 42.0;
-  double primField = 42.0;
-  Object refField = 42;
-  int[] arrayField = new int[]{42};
+  public int instInt = 42;
+  public double instDouble = 42.0;
+  public double primField = 42.0;
+  public Object refField = 42;
+  public int[] arrayField = new int[]{42};
 
-  static int statInt = 43;
+  public static int statInt = 43;
 
   @Test
   public void testInstanceInt() {

--- a/src/tests/gov/nasa/jpf/test/vm/reflection/FieldVisibilityTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/reflection/FieldVisibilityTest.java
@@ -1,0 +1,82 @@
+package gov.nasa.jpf.test.vm.reflection;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * Tests `Class.getField` and `Class.getDeclaredField` on fields of different visibility levels.
+ */
+public class FieldVisibilityTest extends TestJPF {
+    public String publicField;
+    String packagePrivateField;
+    protected String protectedField;
+    private String privateField;
+
+    // Calls `Class.getField` on another class's public field, and checks the returned `Field` object.
+    @Test
+    public void getFieldPublicTest() throws NoSuchFieldException {
+        if (verifyNoPropertyViolation()) {
+            Field f = Integer.class.getField("MAX_VALUE");
+            assertEquals("public static final int java.lang.Integer.MAX_VALUE", f.toString());
+            assertEquals(Integer.class, f.getDeclaringClass());
+            assertEquals("MAX_VALUE", f.getName());
+
+            int modifiers = f.getModifiers();
+            assertTrue(Modifier.isPublic(modifiers));
+            assertTrue(Modifier.isStatic(modifiers));
+            assertTrue(Modifier.isFinal(modifiers));
+        }
+    }
+
+    @Test
+    public void getFieldProtectedTest() throws NoSuchFieldException {
+        if (verifyUnhandledException("java.lang.NoSuchFieldException")) {
+            FieldVisibilityTest.class.getField("protectedField");
+        }
+    }
+
+    @Test
+    public void getFieldPackagePrivateTest() throws NoSuchFieldException {
+        if (verifyUnhandledException("java.lang.NoSuchFieldException")) {
+            FieldVisibilityTest.class.getField("packagePrivateField");
+        }
+    }
+
+    @Test
+    public void getFieldPrivateTest() throws NoSuchFieldException {
+        if (verifyUnhandledException("java.lang.NoSuchFieldException")) {
+            FieldVisibilityTest.class.getField("privateField");
+        }
+    }
+
+    @Test
+    public void getDeclaredFieldSameClassTest() throws NoSuchFieldException {
+        if (verifyNoPropertyViolation()) {
+            assertEquals(FieldVisibilityTest.class.getDeclaredField("publicField").getName(), "publicField");
+            assertEquals(FieldVisibilityTest.class.getDeclaredField("packagePrivateField").getName(), "packagePrivateField");
+            assertEquals(FieldVisibilityTest.class.getDeclaredField("protectedField").getName(), "protectedField");
+            assertEquals(FieldVisibilityTest.class.getDeclaredField("privateField").getName(), "privateField");
+        }
+    }
+
+    @Test
+    public void getDeclaredFieldOtherClassTest() throws NoSuchFieldException {
+        assertEquals(SomeClass.class.getDeclaredField("publicField").getName(), "publicField");
+        assertEquals(SomeClass.class.getDeclaredField("packagePrivateField").getName(), "packagePrivateField");
+        assertEquals(SomeClass.class.getDeclaredField("protectedField").getName(), "protectedField");
+        assertEquals(SomeClass.class.getDeclaredField("privateField").getName(), "privateField");
+    }
+}
+
+/**
+ * A trivial class containing fields of different visibility levels.
+ */
+class SomeClass {
+    public String publicField;
+    String packagePrivateField;
+    protected String protectedField;
+    private String privateField;
+}


### PR DESCRIPTION
* Class.getField should return only public fields

* Added comments on the behavior of `Class.getField` and `Class.getDeclaredField`

(Same as #384)