### PR TITLE
More complete implementation of Field.isAccessible

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
@@ -119,7 +119,6 @@ public class FieldTest extends TestJPF {
       Object o = OtherPackagePublicClass.getPackagePrivateObject();
       Class<?> packagePrivateClass = o.getClass();
       // This is a non-public class from a different package.
-      assertEquals("gov.nasa.jpf.test.java.lang.reflect.other_package", packagePrivateClass.getPackage().getName());
       assertFalse(Modifier.isPublic(packagePrivateClass.getModifiers()));
 
       Field f = packagePrivateClass.getDeclaredField("publicStaticField");

--- a/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/reflect/FieldTest.java
@@ -18,12 +18,15 @@
 
 package gov.nasa.jpf.test.java.lang.reflect;
 
+import gov.nasa.jpf.test.java.lang.reflect.other_package.OtherPackageParent;
+import gov.nasa.jpf.test.java.lang.reflect.other_package.OtherPackagePublicClass;
 import gov.nasa.jpf.util.test.TestJPF;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 import org.junit.Test;
 
@@ -32,6 +35,10 @@ public class FieldTest extends TestJPF {
   public static final int testField1 = 1;
 
   public String testField2;
+
+  private static final int privStaticFinalField = 10;
+  private final int privFinalField = 20;
+  private int privField = 30;
 
   public static void main (String[] args) throws SecurityException, NoSuchFieldException{
     runTestsOfThisClass(args);
@@ -58,6 +65,111 @@ public class FieldTest extends TestJPF {
       assertEquals(f1.toString(), "public static final int gov.nasa.jpf.test.java.lang.reflect.FieldTest.testField1");
       Field f2 = FieldTest.class.getField("testField2");
       assertEquals(f2.toString(), "public java.lang.String gov.nasa.jpf.test.java.lang.reflect.FieldTest.testField2");
+    }
+  }
+
+  @Test
+  public void setFinalFieldErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      FieldTest.class.getDeclaredField("privFinalField").setInt(this, 100);
+    }
+  }
+
+  @Test
+  public void getPublicClassPublicFieldTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      assertEquals(10,  OtherPackagePublicClass.class.getField("publicStaticFinalField").get(null));
+
+      OtherPackagePublicClass obj = new OtherPackagePublicClass(42);
+      assertEquals(10, OtherPackagePublicClass.class.getField("publicStaticFinalField").get(obj));
+      assertEquals(20, OtherPackagePublicClass.class.getField("publicFinalField").get(obj));
+      assertEquals(42, OtherPackagePublicClass.class.getField("publicField").get(obj));
+    }
+  }
+
+  @Test
+  public void getOtherPackageProtectedFieldErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      OtherPackagePublicClass obj = new OtherPackagePublicClass(42);
+      OtherPackagePublicClass.class.getDeclaredField("protectedField").get(obj);
+    }
+  }
+
+  @Test
+  public void getOtherPackagePackagePrivateFieldErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      OtherPackagePublicClass obj = new OtherPackagePublicClass(42);
+      OtherPackagePublicClass.class.getDeclaredField("packagePrivateField").get(obj);
+    }
+  }
+
+  @Test
+  public void getOwnClassFieldTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      assertEquals(10,  FieldTest.class.getDeclaredField("privStaticFinalField").get(null));
+      assertEquals(10,  FieldTest.class.getDeclaredField("privStaticFinalField").get(this));
+      assertEquals(20,  FieldTest.class.getDeclaredField("privFinalField").get(this));
+      assertEquals(30,  FieldTest.class.getDeclaredField("privField").get(this));
+    }
+  }
+
+  @Test
+  public void getInaccessibleClassFieldErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      Object o = OtherPackagePublicClass.getPackagePrivateObject();
+      Class<?> packagePrivateClass = o.getClass();
+      // This is a non-public class from a different package.
+      assertEquals("gov.nasa.jpf.test.java.lang.reflect.other_package", packagePrivateClass.getPackage().getName());
+      assertFalse(Modifier.isPublic(packagePrivateClass.getModifiers()));
+
+      Field f = packagePrivateClass.getDeclaredField("publicStaticField");
+      f.get(null); // Access fields of such a class should be denied, even if the field is public.
+    }
+  }
+
+  @Test
+  public void getSamePackageNonPrivateFieldTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      assertEquals(SamePackageClass.class.getDeclaredField("publicField").get(null), 10);
+
+      // Accessing non-private fields on a class in the same package should be allowed.
+      assertEquals(SamePackageClass.class.getDeclaredField("protectedField").get(null), 20);
+      assertEquals(SamePackageClass.class.getDeclaredField("packagePrivateField").get(null), 30);
+    }
+  }
+
+  @Test
+  public void getSamePackagePrivateFieldErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      SamePackageClass.class.getDeclaredField("privateField").get(new SamePackageClass());
+    }
+  }
+
+  @Test
+  public void getParentStaticProtectedFieldTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      SamePackageClass.getParentStaticProtectedField();
+    }
+  }
+
+  @Test
+  public void getParentProtectedFieldTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      SamePackageClass.getParentProtectedField();
+    }
+  }
+
+  @Test
+  public void getParentProtectedFieldOnParentInstanceErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      SamePackageClass.getParentProtectedFieldOnParentInstanceError();
+    }
+  }
+
+  @Test
+  public void getParentProtectedFieldOnSiblingInstanceErrorTest() throws NoSuchFieldException, IllegalAccessException {
+    if (verifyUnhandledException("java.lang.IllegalAccessException")) {
+      SamePackageClass.getParentProtectedFieldOnSiblingInstanceError();
     }
   }
 
@@ -126,3 +238,51 @@ public class FieldTest extends TestJPF {
     }
   }
 }
+
+/*
+Helper classes:
+
+       OtherPackageParent
+         /           \
+SamePackageClass   SamePackageClass2
+        |
+SamePackageChildClass
+ */
+
+class SamePackageClass extends OtherPackageParent {
+  public static int publicField = 10;
+  protected static int protectedField = 20;
+  static int packagePrivateField = 30;
+  private int privateField = 40;
+
+  // Some test cases live in this separate class, because the behavior of `Field.get` can depend on the caller class.
+
+  static void getParentStaticProtectedField() throws NoSuchFieldException, IllegalAccessException {
+    Field f = OtherPackageParent.class.getDeclaredField("parentStaticProtectedField");
+    TestJPF.assertEquals(40, f.get(null));
+    TestJPF.assertEquals(40, f.get(new SamePackageClass()));
+    TestJPF.assertEquals(40, f.get(new SamePackageClass2()));
+    TestJPF.assertEquals(40, f.get(new OtherPackageParent()));
+    TestJPF.assertEquals(40, f.get(new SamePackageChildClass()));
+  }
+
+  static void getParentProtectedField() throws NoSuchFieldException, IllegalAccessException {
+    Field f = OtherPackageParent.class.getDeclaredField("parentStaticField");
+    TestJPF.assertEquals(50, f.get(new SamePackageClass()));
+    TestJPF.assertEquals(50, f.get(new SamePackageChildClass()));
+  }
+
+  static void getParentProtectedFieldOnParentInstanceError() throws NoSuchFieldException, IllegalAccessException {
+    Field f = OtherPackageParent.class.getDeclaredField("parentStaticField");
+    f.get(new OtherPackageParent()); // Not an instance of the caller class!
+  }
+
+  static void getParentProtectedFieldOnSiblingInstanceError() throws NoSuchFieldException, IllegalAccessException {
+    Field f = OtherPackageParent.class.getDeclaredField("parentStaticField");
+    f.get(new SamePackageClass2()); // Not an instance of the caller class!
+  }
+}
+
+class SamePackageClass2 extends OtherPackageParent {}
+
+class SamePackageChildClass extends SamePackageClass {}

--- a/src/tests/gov/nasa/jpf/test/java/lang/reflect/other_package/OtherPackageParent.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/reflect/other_package/OtherPackageParent.java
@@ -1,0 +1,9 @@
+package gov.nasa.jpf.test.java.lang.reflect.other_package;
+
+/**
+ * Used in gov.nasa.jpf.test.java.lang.reflect.FieldTest as a superclass.
+ */
+public class OtherPackageParent {
+    protected static int parentStaticProtectedField = 40;
+    protected int parentStaticField = 50;
+}

--- a/src/tests/gov/nasa/jpf/test/java/lang/reflect/other_package/OtherPackagePublicClass.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/reflect/other_package/OtherPackagePublicClass.java
@@ -1,0 +1,25 @@
+package gov.nasa.jpf.test.java.lang.reflect.other_package;
+
+/**
+ * Used in gov.nasa.jpf.test.java.lang.reflect.FieldTest.
+ */
+public class OtherPackagePublicClass {
+    public static final int publicStaticFinalField = 10;
+    public final int publicFinalField = 20;
+    public int publicField;
+
+    protected int protectedField = 30;
+    int packagePrivateField = 40;
+
+    public OtherPackagePublicClass(int v) {
+        this.publicField = v;
+    }
+
+    public static OtherPackageInternalClass getPackagePrivateObject() {
+        return new OtherPackageInternalClass();
+    }
+}
+
+class OtherPackageInternalClass {
+    public static int publicStaticField = 88;
+}


### PR DESCRIPTION
Same as #386, except that in one of the tests I removed a (non-essential) call to `Class.getPackage`, which seems to be currently unsupported:

```
gov.nasa.jpf.vm.NoUncaughtExceptionsProperty
java.lang.NoSuchMethodError: java.lang.ClassLoader.getUnnamedModule()Ljava/lang/Module;
    at java.lang.Package.<init>(Package.java:518)
    at java.lang.Class.getPackage(Class.java:159)
    at gov.nasa.jpf.test.java.lang.reflect.FieldTest.getInaccessibleClassFieldErrorTest(FieldTest.java:122)
    at java.lang.reflect.Method.invoke(gov.nasa.jpf.vm.JPF_java_lang_reflect_Method)
    at gov.nasa.jpf.util.test.TestJPF.runTestMethod(TestJPF.java:648)
```