### PR TITLE
Modify Types.instanceOf to take a ClassInfo as LHS

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java
@@ -30,25 +30,25 @@ import gov.nasa.jpf.vm.Types;
  * ..., objectref => ..., result
  */
 public class INSTANCEOF extends Instruction implements JVMInstruction {
-  private String type;
+  private String typeSignature;
 
 
   /**
    * typeName is of a/b/C notation
    */
   public INSTANCEOF (String typeName){
-    type = Types.getTypeSignature(typeName, false);
+    typeSignature = Types.getTypeSignature(typeName, false);
   }
 
   @Override
   public Instruction execute (ThreadInfo ti) {
-    if(Types.isReferenceSignature(type)) {
+    if(Types.isReferenceSignature(typeSignature)) {
       String t;
-      if(Types.isArray(type)) {
+      if(Types.isArray(typeSignature)) {
         // retrieve the component terminal
-        t = Types.getComponentTerminal(type);
+        t = Types.getComponentTerminal(typeSignature);
       } else {
-        t = type;
+        t = typeSignature;
       }
 
       // resolve the referenced class
@@ -64,7 +64,7 @@ public class INSTANCEOF extends Instruction implements JVMInstruction {
 
     if (objref == MJIEnv.NULL) {
       frame.push(0);
-    } else if (ti.getElementInfo(objref).instanceOf(type)) {
+    } else if (ti.getElementInfo(objref).instanceOf(typeSignature)) {
       frame.push(1);
     } else {
       frame.push(0);
@@ -74,7 +74,7 @@ public class INSTANCEOF extends Instruction implements JVMInstruction {
   }
   
   public String getType() {
-	  return type;
+	  return typeSignature;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/ElementInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ElementInfo.java
@@ -1679,8 +1679,8 @@ public abstract class ElementInfo implements Cloneable {
     
   }
 
-  public boolean instanceOf(String type) {
-    return Types.instanceOf(ci.getType(), type);
+  public boolean instanceOf(String typeSignature) {
+    return Types.instanceOf(ci, typeSignature);
   }
 
   abstract public int getNumberOfFields();

--- a/src/main/gov/nasa/jpf/vm/Types.java
+++ b/src/main/gov/nasa/jpf/vm/Types.java
@@ -1070,30 +1070,18 @@ public class Types {
     return (int) (l >> 32);
   }
 
-  public static boolean instanceOf (String type, String ofType) {
-    int bType = getBuiltinTypeFromSignature(type);
-
-    if ((bType == T_ARRAY) && ofType.equals("Ljava/lang/Object;")) {
-      return true;
+  public static boolean instanceOf (ClassInfo ci, String ofTypeSignature) {
+    int bOfType = getBuiltinTypeFromSignature(ofTypeSignature);
+    if (ci.isArray() && bOfType == T_ARRAY) {
+      return instanceOf(ci.getComponentClassInfo(), getArrayElementType(ofTypeSignature));
     }
 
-    int bOfType = getBuiltinTypeFromSignature(ofType);
-
-    if (bType != bOfType) {
-      return false;
+    if (ci.isPrimitive()) {
+      int bType = getBuiltinTypeFromSignature(ci.getSignature());
+      return bType == bOfType;
     }
 
-    switch (bType) {
-    case T_ARRAY:
-      return instanceOf(type.substring(1), ofType.substring(1));
-
-    case T_REFERENCE:
-      ClassInfo ci = ClassLoaderInfo.getCurrentResolvedClassInfo(getTypeName(type));
-      return ci.isInstanceOf(getTypeName(ofType));
-
-    default:
-      return true;
-    }
+    return ci.isInstanceOf(getTypeName(ofTypeSignature));
   }
 
   public static boolean intToBoolean (int i) {

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassLoaderTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassLoaderTest.java
@@ -21,6 +21,7 @@ import gov.nasa.jpf.util.test.TestJPF;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.Enumeration;
 
@@ -207,7 +208,19 @@ public class ClassLoaderTest extends TestJPF {
       Class<?> cls2 = classLoader.loadMagic();
     }
   }
- 
+
+  @Test
+  public void testDefineClassInstanceOf() throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    if (verifyNoPropertyViolation()) {
+      TestClassLoader testClassLoader = new TestClassLoader();
+      testClassLoader.defineClassWithDefaultConstructor("example/MyClass1");
+      Class<?> cls2 = testClassLoader.defineClassWithDefaultConstructor("example/MyClass2");
+      Object obj = cls2.getConstructor().newInstance();
+      boolean objIsInstanceOfObject = obj instanceof Object;
+      assertTrue(objIsInstanceOfObject);
+    }
+  }
+
   class TestClassLoader extends ClassLoader {
       
     public TestClassLoader() {
@@ -235,6 +248,25 @@ public class ClassLoaderTest extends TestJPF {
 
       byte[] bytes = cw.toByteArray();
 	  return defineClass("sun.reflect.GroovyMagic", bytes, 0, bytes.length);
+    }
+
+    // Defines a trivial class with a default constructor.  `name` should have the format `example/MyClass`.
+    public Class<?> defineClassWithDefaultConstructor(String name) {
+      ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+      cw.visit(Opcodes.V1_4, Opcodes.ACC_PUBLIC, name, null, "java/lang/Object", null);
+
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+      mv.visitCode();
+      mv.visitVarInsn(Opcodes.ALOAD, 0);
+      mv.visitMaxs(0, 0);
+      // Invoke super constructor.
+      mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+      mv.visitInsn(Opcodes.RETURN);
+      mv.visitEnd();
+
+      cw.visitEnd();
+      byte[] bytes = cw.toByteArray();
+      return defineClass(name.replace('/', '.'), bytes, 0, bytes.length);
     }
   }
 }

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -637,10 +637,48 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
   }  
 
   @Test
-  public void instanceOfArrayTest() {
-    String[] args = new String[0];
+  public void instanceOfPrimitiveArrayTest() {
+    int[] intArr = new int[10];
+
     if (verifyNoPropertyViolation()) {
-      assert args instanceof Object;
+      // Every array is an instance of Object, Cloneable, and Serializable.
+      // https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.10.3
+      assertTrue(intArr instanceof Object);
+      assertTrue(intArr instanceof Cloneable);
+      assertTrue(intArr instanceof Serializable);
+
+      assertTrue(intArr instanceof int[]);
+    }
+  }
+
+  @Test
+  public void instanceOfReferenceArrayTest() {
+    Child1[] arr = new Child1[0];
+
+    if (verifyNoPropertyViolation()) {
+      assertTrue(arr instanceof Object);
+      assertTrue(arr instanceof Cloneable);
+      assertTrue(arr instanceof Serializable);
+
+      assertTrue(arr instanceof Child1[]);
+      assertTrue(arr instanceof Parent[]);
+      assertTrue(arr instanceof Object[]);
+      assertFalse(arr instanceof Child2[]);
+    }
+  }
+
+  @Test
+  public void instanceOfNestedArrayTest() {
+    int[][] intArr = new int[10][10];
+    Child1[][] child1Arr = new Child1[0][0];
+
+    if (verifyNoPropertyViolation()) {
+      assertTrue(intArr instanceof int[][]);
+
+      assertTrue(child1Arr instanceof Child1[][]);
+      assertTrue(child1Arr instanceof Parent[][]);
+      assertTrue(child1Arr instanceof Object[][]);
+      assertFalse(child1Arr instanceof Child2[][]);
     }
   }
 }


### PR DESCRIPTION
This method's declaration currently reads `instanceOf(String, String)`, taking both the LHS and RHS types as type signature strings.  As a result, to use a `ClassInfo` object `ci` as the LHS, a caller must convert it into a string via `ci.getType()` (see `ElementInfo.instanceOf`), before the string eventually gets turned back into a `ClassInfo` object (if it's a reference type) in the method body.

This patch changes the method declaration to read `instanceOf(ClassInfo, String)`.  This change not only saves the back-and-forth, but also addresses the case where the LHS class has been loaded by a non-default class loader, in which case the original implementation fails to resolve its type string back into a `ClassInfo`.  Fixes https://github.com/javapathfinder/jpf-core/issues/383.

This patch also simplifies the implementation of `instanceOf`, ensures it recognizes arrays as subtypes of Cloneable and Serializable (JLS 4.10.3), changes the names of a few variables to clarify they're expected to contain type signatures, and adds unit tests (to `ClassTest.java`, where the existing `testInstanceOf` unit test resides).

One downside is that if LHS is a nested array, the new implementation will resolve a `ClassInfo` object for every "layer" of the array (via `ClassInfo.getComponentClassInfo`), while the original implementation "peels" the array via (cheaper) calls to `String.substring`.  I'm guessing this performance degradation will not be noticeable in common scenarios.