### PR TITLE
Apply patch to add PrintStreamTest and add patch for #172 to fix PrintStreamTest

### DIFF
--- a/src/classes/modules/java.base/java/util/regex/Matcher.java
+++ b/src/classes/modules/java.base/java/util/regex/Matcher.java
@@ -67,6 +67,8 @@ public class Matcher {
   public native boolean matches();
   
   public native boolean find();
+
+  public native boolean find(int start);
   
   public native boolean lookingAt();
   

--- a/src/main/gov/nasa/jpf/vm/MJIEnv.java
+++ b/src/main/gov/nasa/jpf/vm/MJIEnv.java
@@ -1137,7 +1137,7 @@ public class MJIEnv {
           arg[i] = getBooleanObject(ref);
         } else if (clsName.equals("java.lang.Byte")) {
           arg[i] = getByteObject(ref);
-        } else if (clsName.equals("java.lang.Char")) {
+        } else if (clsName.equals("java.lang.Character")) {
           arg[i] = getCharObject(ref);
         } else if (clsName.equals("java.lang.Short")) {
           arg[i] = getShortObject(ref);
@@ -1171,7 +1171,7 @@ public class MJIEnv {
 	          arg[i] = getStringObject(ref);
 	        } else if (clsName.equals("java.lang.Byte")) {
 	          arg[i] = getByteObject(ref);
-	        } else if (clsName.equals("java.lang.Char")) {
+	        } else if (clsName.equals("java.lang.Character")) {
 	          arg[i] = getCharObject(ref);
 	        } else if (clsName.equals("java.lang.Short")) {
 	          arg[i] = getShortObject(ref);

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_Field.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_Field.java
@@ -758,7 +758,7 @@ public class JPF_java_lang_reflect_Field extends NativePeer {
       
       if (fi.isBooleanField() && valClsName.equals("java.lang.Boolean")) return true;
       else if (fi.isByteField() && valClsName.equals("java.lang.Byte")) return true;
-      else if (fi.isCharField() && valClsName.equals("java.lang.Char")) return true;
+      else if (fi.isCharField() && valClsName.equals("java.lang.Character")) return true;
       else if (fi.isShortField() && valClsName.equals("java.lang.Short")) return true;
       else if (fi.isIntField() && valClsName.equals("java.lang.Integer")) return true;
       else if (fi.isLongField() && valClsName.equals("java.lang.Long")) return true;

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
@@ -74,6 +74,12 @@ public class JPF_java_util_regex_Matcher extends NativePeer {
   }
   
   @MJI
+  public boolean find__I__Z (MJIEnv env, int objref, int i) {
+	Matcher matcher = getInstance( env, objref);
+    return matcher.find(i);
+  }
+
+  @MJI
   public boolean find____Z (MJIEnv env, int objref) {
 	Matcher matcher = getInstance( env, objref);
     return matcher.find();

--- a/src/tests/gov/nasa/jpf/test/java/io/PrintStreamTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/io/PrintStreamTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.java.io;
+
+import gov.nasa.jpf.util.test.TestJPF;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+/**
+ * regression test for object streams
+ */
+public class PrintStreamTest extends TestJPF {
+
+  @Test 
+  public void testPrintCharFormat () {
+    if (verifyNoPropertyViolation()){
+	ByteArrayOutputStream baos = new ByteArrayOutputStream(1);
+	PrintStream baps = new PrintStream(baos, true);
+	baps.printf("%c", 'a'); 
+	assert (baos.toByteArray()[0] == 97);
+    }
+  }
+}


### PR DESCRIPTION
This commit contains 2 patches:
1. Use java.lang.Character instead of java.lang.char and adds the PrintStreamTest - commit [f7336c4](https://github.com/javapathfinder/jpf-core/commit/f7336c4df1322b1d586c0ebc34c10fd57f340667#diff-23f2449034ab5d4b6acf3bade57e37bac214f7bc9b40e1949b38bc3f48c700a8)
2. Fixes the PrintStreamTest's printf() method - #172 

None of the 934 tests break