### PR TITLE
Apply patch for #181 to add CalendarTest

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/util/CalendarTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/util/CalendarTest.java
@@ -1,0 +1,26 @@
+package gov.nasa.jpf.test.java.util;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Calendar;
+
+public class CalendarTest extends TestJPF {
+
+    @Test
+    public void testCalendarHourSet(){
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        Assert.assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
+    }
+
+    @Test
+    public void testCalendarHourSetAfterYear(){
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.YEAR, 2014);
+        cal.set(Calendar.HOUR_OF_DAY, 23);
+        Assert.assertEquals(2014, cal.get(Calendar.YEAR));
+        Assert.assertEquals(23, cal.get(Calendar.HOUR_OF_DAY));
+    }
+
+}


### PR DESCRIPTION
Imports patch to add the CalendarTest originally defined as part of #181 

1 new test added. Does not break anything. All of the 935 tests pass.