### PR TITLE
Apply patch for #182 to add peer and test for AtomicReference

### DIFF
--- a/src/main/gov/nasa/jpf/vm/NativePeer.java
+++ b/src/main/gov/nasa/jpf/vm/NativePeer.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 /**
  * native peer classes are part of MJI and contain the code that is
  * executed by the host VM (i.e. outside the state-tracked JPF VM). Each
- * class executed by JPF that has native mehods must have a native peer class
+ * class executed by JPF that has native methods must have a native peer class
  * (which is looked up and associated at class loadtime)
  */
 public class NativePeer implements Cloneable {

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_util_concurrent_atomic_AtomicReference.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_util_concurrent_atomic_AtomicReference.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.vm;
+
+import gov.nasa.jpf.annotation.MJI;
+
+/**
+* native peer for java.util.concurrent.atomic.AtomicReference
+* this implementation just cuts off native methods
+*/
+public class JPF_java_util_concurrent_atomic_AtomicReference extends NativePeer {
+
+  @MJI
+  public void $clinit____V (MJIEnv env, int rcls) {
+    // don't let this one pass, it calls native methods from non-public Sun classes
+  }
+
+  @MJI
+  public int getAndSet__Ljava_lang_Object_2__Ljava_lang_Object_2 (MJIEnv env, int objRef, int newValue) {
+    int value = env.getReferenceField(objRef, "value");
+    env.setReferenceField(objRef, "value", newValue);
+    return value;
+  }
+
+
+  @MJI
+  public boolean compareAndSet__Ljava_lang_Object_2Ljava_lang_Object_2__Z (MJIEnv env, int objRef, int expect, int update){
+    int value = env.getReferenceField(objRef, "value");
+    if (value == expect){
+      env.setReferenceField(objRef, "value", update);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/tests/gov/nasa/jpf/test/java/concurrent/AtomicReferenceTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/concurrent/AtomicReferenceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gov.nasa.jpf.test.java.concurrent;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import gov.nasa.jpf.vm.Verify;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * raw test for java.util.concurrent.atomic.AtomicReference
+ */
+public class AtomicReferenceTest extends TestJPF {
+
+  static {
+    Verify.setProperties("cg.enumerate_cas=true");
+  }
+
+  @Test
+  public void testNonWeakUpdates() {
+    if (verifyNoPropertyViolation("+cg.enumerate_cas=true")) {
+      final AtomicReference<String> ref = new AtomicReference<String>("initial value");
+
+      assertTrue(ref.compareAndSet("initial value", "second value"));
+
+      assertEquals(ref.get(), "second value");
+
+      assertFalse(ref.compareAndSet("initial value", "don't set"));
+
+      assertEquals(ref.get(), "second value");
+
+      assertEquals(ref.getAndSet("final value"), "second value");
+
+      assertEquals(ref.get(), "final value");
+    }
+  }
+}


### PR DESCRIPTION
This patch adds a new test `AtomicReferenceTest`

All tests (934) pass.