### PR TITLE
Apply patch to fix division by zero in DDIV and adds 2 tests

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/bytecode/DDIV.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/DDIV.java
@@ -34,11 +34,6 @@ public class DDIV extends Instruction implements JVMInstruction {
 
     double v1 = frame.popDouble();
     double v2 = frame.popDouble();
-    
-    if (v1 == 0) {
-        return ti.createAndThrowException("java.lang.ArithmeticException",
-                                          "division by zero");
-    }
 
     double r = v2 / v1;
     

--- a/src/tests/gov/nasa/jpf/test/java/lang/DoubleTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/DoubleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.java.lang;
+
+import gov.nasa.jpf.util.test.TestJPF;
+
+import org.junit.Test;
+
+/**
+ * double related tests
+ */
+public class DoubleTest extends TestJPF {
+
+  @Test
+  public void testDivision() {
+    if (verifyNoPropertyViolation()) {
+      double i = 0;
+      double j = 10 / i;
+      assert(Double.valueOf(j).isInfinite());
+    }
+  }
+}

--- a/src/tests/gov/nasa/jpf/test/java/lang/FloatTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/FloatTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.java.lang;
+
+import gov.nasa.jpf.util.test.TestJPF;
+
+import org.junit.Test;
+
+/**
+ * float related tests
+ */
+public class FloatTest extends TestJPF {
+
+  @Test
+  public void testDivision() {
+    if (verifyNoPropertyViolation()) {
+      float i = 0;
+      float j = 10 / i;
+      assert(Float.valueOf(j).isInfinite());
+    }
+  }
+}


### PR DESCRIPTION
The original patch can be found [here](https://github.com/javapathfinder/jpf-core/commit/5cfe5f6b3052fc76ef16c15ad11a177c479c1920).

Two tests have been added:
1. `DoubleTest.java`
2. `FloatTest.java`

All the 935 tests pass. Patch does not break anything.

Thanks!