### PR TITLE
Apply patch to add support for halt() in the Runtime peer

### DIFF
--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Runtime.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Runtime.java
@@ -62,6 +62,14 @@ public class JPF_java_lang_Runtime extends NativePeer {
   public void gc____V (MJIEnv env, int objref){
     env.gc();
   }
+
+  @MJI
+  public void halt__I__V (MJIEnv env, int clsObjRef, int ret) {
+    // TODO: System.exit should start shutdown handler (once supported)
+    // and call this method (copied code should be removed in System.exit)
+    ThreadInfo ti = env.getThreadInfo();
+    env.getVM().terminateProcess(ti);
+  }
   
   @MJI
   public int availableProcessors____I (MJIEnv env, int objref){

--- a/src/tests/gov/nasa/jpf/test/java/lang/RuntimeTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/RuntimeTest.java
@@ -26,6 +26,22 @@ import org.junit.Test;
 public class RuntimeTest extends TestJPF {
 
   @Test
+  public void testExit() {
+    if (verifyNoPropertyViolation()) {
+      System.exit(1);
+      assert(false);
+    }
+  }
+
+  @Test
+  public void testHalt() {
+    if (verifyNoPropertyViolation()) {
+      Runtime.getRuntime().halt(1);
+      assert(false);
+    }
+  }
+
+  @Test
   public void testAvailableProcessors() {
 
     if (!isJPFRun()) {


### PR DESCRIPTION
Original commit can be found [here](https://github.com/javapathfinder/jpf-core/commit/c42e4fc591a787c17954e63dbbc2cf9668c6ae39).

Adds 2 tests:
1. `RuntimeTest.testExit()`
2. `RuntimeTest.testHalt()`

All tests pass (945).

Thanks!