### PR TITLE
Apply patch to add test for redirection of stdout to a file

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/io/FileIOTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/io/FileIOTest.java
@@ -20,6 +20,7 @@ package gov.nasa.jpf.test.java.io;
 
 import gov.nasa.jpf.util.test.TestJPF;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Random;
@@ -113,6 +115,20 @@ public class FileIOTest extends TestJPF {
       }
 
       System.out.println("##---- done");
+    }
+  }
+
+  @Test
+  public void testRedirection() throws IOException {
+    if (verifyNoPropertyViolation()) {
+        System.out.println("Before.");
+        FileOutputStream out = new FileOutputStream("output.txt");
+        System.setOut(new PrintStream(new BufferedOutputStream(out), true));
+        System.out.println("After.");
+        out.close();
+        FileInputStream is = new FileInputStream(new File("output.txt"));
+        assert (is.read() == (int)'A');
+        is.close();
     }
   }
 


### PR DESCRIPTION
Original commit can be found [here](https://github.com/javapathfinder/jpf-core/commit/2fc7c6100c2bb7cf4452ecfd72a628d6c06e3188).

The patch adds one new test to the `FileIOTest` test:
1. `testRedirection()`

All of the 944 tests pass.

Thanks!