### PR TITLE
Apply patches for #295 to add extension to systematically inject and test for bit-flip faults 

### DIFF
--- a/src/annotations/gov/nasa/jpf/annotation/BitFlip.java
+++ b/src/annotations/gov/nasa/jpf/annotation/BitFlip.java
@@ -1,0 +1,17 @@
+package gov.nasa.jpf.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Pu Yi <lukeyi@pku.edu.cn>
+ *
+ * An annotation used to specify fields/parameters to perform bit flipping exploration
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.LOCAL_VARIABLE })
+public @interface BitFlip {
+  int value() default 1;
+}

--- a/src/main/fault/injection/examples/APISimpleExample.java
+++ b/src/main/fault/injection/examples/APISimpleExample.java
@@ -1,0 +1,12 @@
+package fault.injection.examples;
+
+import gov.nasa.jpf.vm.Verify;
+
+/*
+ * Use getBitFlip API to inject a bit flip to a variable
+ */
+public class APISimpleExample {
+    public static void main(String[] args) {
+        System.out.println(Verify.getBitFlip((byte)0, 2));
+    }
+}

--- a/src/main/fault/injection/examples/AnnotationSimpleExample.java
+++ b/src/main/fault/injection/examples/AnnotationSimpleExample.java
@@ -1,0 +1,16 @@
+package fault.injection.examples;
+
+import gov.nasa.jpf.vm.Verify;
+import gov.nasa.jpf.annotation.BitFlip;
+
+/*
+ * Use @BitFlip annotation to inject a bit flip to an argument
+ */
+public class AnnotationSimpleExample {
+    public static void foo(@BitFlip byte bar) {
+        System.out.println(bar);
+    }
+    public static void main(String[] args) {
+        foo((byte)0);
+    }
+}

--- a/src/main/fault/injection/examples/BCDEncodedISBN.java
+++ b/src/main/fault/injection/examples/BCDEncodedISBN.java
@@ -1,0 +1,77 @@
+package fault.injection.examples;
+
+import gov.nasa.jpf.vm.Verify;
+
+/*
+ * International Standard Book Number (ISBN) error detection
+ * BCD variant
+ */
+public class BCDEncodedISBN {
+
+    // get the i-th (indexed from 0) decimal number
+    static int getNumber (long digits, int i) {
+        return (int) ((digits >> (i << 2)) & 15);
+    }
+
+    // calculate the check digit for ISBN-10 based on the first 9 digits
+    public static int calculate10 (long digits) {
+        int s = 0, t = 0;
+        for (int i = 0; i < 9; ++i) {
+            int digit = getNumber(digits, i);
+            t += digit;
+            s += t;
+        }
+        return (11 - (s + t) % 11) % 11;
+    }
+
+    // ISBN-10 check
+    public static boolean check10 (long digits) {
+        // invalid if more than 10 decimal numbers
+        if ((digits >> 40) != 0)
+            return false;
+        for (int i = 0; i < 10; ++i) {
+            if (getNumber(digits, i) > 10 || (getNumber(digits, i) == 10 && i != 9))
+                return false;
+        }
+        return getNumber(digits, 9) == calculate10(digits);
+    }
+
+    // calculate the check digit for ISBN-13 based on the first 12 digits
+    public static int calculate13 (long digits) {
+        int s = 0, t = 1;
+        for (int i = 0; i < 12; ++i) {
+            s += getNumber(digits, i) * t;
+            t = 4 - t;
+        }
+        return (10 - s % 10) % 10;
+    }
+
+    // ISBN-13 check
+    public static boolean check13 (long digits) {
+        // invalid if more than 13 decimal numbers
+        if ((digits >> 52) != 0)
+            return false;
+        for (int i = 0; i < 13; ++i) {
+            if (getNumber(digits, i) < 0 || getNumber(digits, i) > 9)
+                return false;
+        }
+        return getNumber(digits, 12) == calculate13(digits);
+    }
+
+    // given the first 9 digits, generate the 10th, and check that one bit flip will always be detected
+    public static void main (String[] args) {
+        assert (args[0].length() == 9);
+        long digits = 0;
+        for (int i = 0; i < 9; ++i) {
+            char c = args[0].charAt(i);
+            assert (c >= '0' && c <= '9');
+            digits |= ((long) (c - '0')) << (i << 2);
+        }
+        digits |= ((long) calculate10(digits)) << (9 << 2);
+        assert (check10(digits));
+        digits = Verify.getBitFlip(digits, 2, 40);
+        if (check10(digits)) {
+            System.out.println("Masked case: " + digits);
+        }
+    }
+}

--- a/src/main/fault/injection/examples/CRC.java
+++ b/src/main/fault/injection/examples/CRC.java
@@ -1,0 +1,53 @@
+package fault.injection.examples;
+
+/*
+ * Cyclic redundancy check algorithm
+ * Assume the CRC algorithm is performed in GF(2)
+ */
+public class CRC {
+
+    int n; // divisor's length
+    int[] d; // the divisor
+
+    CRC (String divisor) {
+        n = divisor.length();
+        d = new int[n];
+        for (int i = 0; i < n; ++i) {
+            assert (divisor.charAt(i) == '0' || divisor.charAt(i) == '1');
+            d[i] = divisor.charAt(n-1-i) - '0';
+        }
+    }
+
+    // calculate the remainder of the given bit string
+    public String remainder (String s) {
+        // convert string to int array
+        String padded = new String(s);
+        for (int i = 0; i < n-1; ++i)
+            padded += "0";
+        int len = padded.length();
+        int[] r = new int[len];
+        for (int i = 0; i < len; ++i)
+            r[i] = padded.charAt(len-1-i) - '0';
+        for (int i = len-1; i >= n-1; --i) {
+            if (r[i] == 1) {
+                for (int j = 0; j < n; ++j)
+                    r[i-j] ^= d[n-1-j];
+            }
+        }
+        String res = "";
+        for (int i = n-2; i >= 0; --i)
+            res += r[i];
+        return res;
+    }
+
+    // check the data integrity
+    public boolean check (String s, String r) {
+        if (s == null)
+            return false;
+        for (char c : s.toCharArray()) {
+            if (c != '0' && c != '1')
+                return false;
+        }
+        return remainder(s).equals(r);
+    }
+}

--- a/src/main/fault/injection/examples/CheckISBN.java
+++ b/src/main/fault/injection/examples/CheckISBN.java
@@ -1,0 +1,46 @@
+package fault.injection.examples;
+
+/*
+ * International Standard Book Number (ISBN) error detection
+ */
+public class CheckISBN {
+    // calculate the check digit for ISBN-10 based on the first 9 digits
+    public static int calculate10 (int[] digits) {
+        int s = 0, t = 0;
+        for (int i = 0; i < 9; ++i) {
+            t += digits[i];
+            s += t;
+        }
+        return (11 - (s + t) % 11) % 11;
+    }
+    // ISBN-10 check
+    public static boolean check10 (int[] digits) {
+        if (digits == null || digits.length != 10)
+            return false;
+        for (int i = 0; i < 10; ++i) {
+            if (digits[i] < 0 || digits[i] > 10 || (digits[i] == 10 && i != 9))
+                return false;
+        }
+        return digits[9] == calculate10(digits);
+    }
+
+    // calculate the check digit for ISBN-13 based on the first 12 digits
+    public static int calculate13 (int[] digits) {
+        int s = 0, t = 1;
+        for (int i = 0; i < 12; ++i) {
+            s += digits[i] * t;
+            t = 4 - t;
+        }
+        return (10 - s % 10) % 10;
+    }
+    // ISBN-13 check
+    public static boolean check13 (int[] digits) {
+        if (digits == null || digits.length != 13)
+            return false;
+        for (int i = 0; i < 13; ++i) {
+            if (digits[i] < 0 || digits[i] > 9)
+                return false;
+        }
+        return digits[12] == calculate13(digits);
+    }
+}

--- a/src/main/fault/injection/examples/LongEncodedCRC.java
+++ b/src/main/fault/injection/examples/LongEncodedCRC.java
@@ -1,0 +1,63 @@
+package fault.injection.examples;
+
+import gov.nasa.jpf.vm.Verify;
+
+/*
+ * Cyclic redundancy check algorithm
+ * Assume the CRC algorithm is performed in GF(2)
+ * Assume the data length is less than 64 bits, and encode them in a variable of type long
+ */
+public class LongEncodedCRC {
+
+    int n; // divisor's length
+    long d; // the divisor
+
+    LongEncodedCRC (String divisor) {
+        n = divisor.length();
+        d = 0;
+        for (int i = 0; i < n; ++i) {
+            assert (divisor.charAt(i) == '0' || divisor.charAt(i) == '1');
+            d |= ((long) (divisor.charAt(n-1-i) - '0')) << i;
+        }
+    }
+
+    LongEncodedCRC (long _d) {
+        d = _d;
+        assert (d != 0);
+        for (int i = 0; i < 64; ++i)
+            if ((d >> i & 1) == 1) {
+                n = i;
+            }
+    }
+
+    // calculate the remainder of the given bit string
+    public long remainder (int len, long s) {
+        long r = s << (n-1);
+        len += n-1;
+        for (int i = len-1; i >= n-1; --i) {
+            if ((r >> i & 1) == 1) {
+                r ^= d << (i-n+1);
+            }
+        }
+        return r;
+    }
+
+    // check the data integrity
+    public boolean check (int len, long dataWithCheckBits) {
+        long data = dataWithCheckBits >> (n-1);
+        long checkBits = dataWithCheckBits & ((1 << (n-1)) - 1);
+        return remainder(len, data) == checkBits;
+    }
+
+    // check that bit flips in the data can be detected
+    public static void main (String[] args) {
+        LongEncodedCRC crc = new LongEncodedCRC("1011");
+        int len = 14;
+        long dataWithCheckBits = 0b11010011101100100l;
+        assert (crc.check(len, dataWithCheckBits));
+        long flippedData = Verify.getBitFlip(dataWithCheckBits, 2, 17);
+        if (crc.check(len, flippedData)) {
+            System.out.println("Masked case: " + flippedData);
+        }
+    }
+}

--- a/src/main/gov/nasa/jpf/listener/BitFlipListener.java
+++ b/src/main/gov/nasa/jpf/listener/BitFlipListener.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.listener;
+
+import gov.nasa.jpf.Config;
+import gov.nasa.jpf.JPF;
+import gov.nasa.jpf.ListenerAdapter;
+import gov.nasa.jpf.JPFException;
+import gov.nasa.jpf.jvm.bytecode.ARETURN;
+import gov.nasa.jpf.jvm.bytecode.ASTORE;
+import gov.nasa.jpf.jvm.bytecode.JVMInvokeInstruction;
+import gov.nasa.jpf.jvm.bytecode.PUTFIELD;
+import gov.nasa.jpf.jvm.bytecode.PUTSTATIC;
+import gov.nasa.jpf.jvm.bytecode.RETURN;
+import gov.nasa.jpf.report.ConsolePublisher;
+import gov.nasa.jpf.report.Publisher;
+import gov.nasa.jpf.vm.AnnotationInfo;
+import gov.nasa.jpf.vm.choice.IntIntervalGenerator;
+import gov.nasa.jpf.vm.ClassInfo;
+import gov.nasa.jpf.vm.ElementInfo;
+import gov.nasa.jpf.vm.FieldInfo;
+import gov.nasa.jpf.vm.Instruction;
+import gov.nasa.jpf.vm.IntChoiceGenerator;
+import gov.nasa.jpf.vm.LocalVarInfo;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.MethodInfo;
+import gov.nasa.jpf.vm.StackFrame;
+import gov.nasa.jpf.vm.SystemState;
+import gov.nasa.jpf.vm.ThreadInfo;
+import gov.nasa.jpf.vm.Types;
+import gov.nasa.jpf.vm.VM;
+import gov.nasa.jpf.vm.bytecode.FieldInstruction;
+import gov.nasa.jpf.vm.bytecode.InstanceFieldInstruction;
+import gov.nasa.jpf.vm.bytecode.InstanceInvokeInstruction;
+import gov.nasa.jpf.vm.bytecode.InstructionInterface;
+import gov.nasa.jpf.vm.bytecode.InvokeInstruction;
+import gov.nasa.jpf.vm.bytecode.LocalVariableInstruction;
+import gov.nasa.jpf.vm.bytecode.ReturnInstruction;
+import gov.nasa.jpf.vm.bytecode.ReturnValueInstruction;
+import gov.nasa.jpf.vm.bytecode.WriteInstruction;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BitFlipListener extends ListenerAdapter {
+
+  static HashMap<String, Long> lastFlippedBits;
+  static int[][] binomial;
+  static {
+    initializeBinomial();
+    lastFlippedBits = new HashMap<>();
+  }
+  /**
+   * initialize the binomial coefficients by Pascal's triangle
+   * allow up to 7 bits to flip to avoid state explosion that JPF cannot handle
+   */
+  public static void initializeBinomial () {
+    binomial = new int[65][8];
+    binomial[0][0] = binomial[1][0] = binomial[1][1] = 1;
+    for (int i = 2; i <= 64; ++i) {
+      binomial[i][0] = 1;
+      if (i < 8) {
+        binomial[i][i] = 1;
+      }
+      for (int j = 1; j < i && j < 8; ++j) {
+        binomial[i][j] = binomial[i-1][j] + binomial[i-1][j-1];
+      }
+    }
+  }
+
+  public void bitFlip (StackFrame frame, int off, int len, int nBit, int choice, String key) {
+    long v = (len <= 32) ? (long)frame.peek(off) : frame.peekLong(off);
+    v ^= lastFlippedBits.containsKey(key) ? lastFlippedBits.get(key) : 0;
+    long flippedBits = 0;
+    for (int i = len-1; i >= 0; --i) {
+      if (choice >= binomial[i][nBit]) {
+        v ^= (1l << i);
+        flippedBits ^= (1l << i);
+        choice -= binomial[i][nBit];
+        nBit--;
+      }
+    }
+    lastFlippedBits.put(key, flippedBits);
+    int top = frame.getTopPos();
+    if (len <= 32) {
+      frame.setLocalVariable(top-off, (int)v);
+    } else {
+      frame.setLongLocalVariable(top-off-1, v);
+    }
+  }
+
+  /**
+   * inject bit flips for parameters annotated with @BitFlip
+   * permit to inject bit flips to only one parameter
+   */
+  @Override
+  public void executeInstruction (VM vm, ThreadInfo ti, Instruction insnToExecute) {
+    if (insnToExecute instanceof JVMInvokeInstruction) {
+      MethodInfo mi = ((JVMInvokeInstruction) insnToExecute).getInvokedMethod();
+      int idx = -1, offset = -1, nBit = -1;
+
+      byte[] argTypes = mi.getArgumentTypes();
+      int n = argTypes.length;
+      for (int i = n-1, off = 0; i >= 0; --i) {
+        int value = 0;
+        AnnotationInfo[] annotations = mi.getParameterAnnotations(i);
+        if (annotations != null) {
+          for (AnnotationInfo a : annotations) {
+            if ("gov.nasa.jpf.annotation.BitFlip".equals(a.getName())) {
+              value = a.getValueAsInt("value");
+            }
+          }
+        }
+        if (value < 0 || value > 7) {
+          throw new JPFException("Invalid number of bits to flip: should be between 1 and 7");
+        }
+        if (value > 0) {
+          idx = i;
+          offset = off;
+          nBit = value;
+          break;
+        }
+        off += Types.getTypeSize(argTypes[i]);
+      }
+
+      if (idx != -1) {
+        String key = mi.getFullName() + ":ParameterBitFlip";
+        SystemState ss = vm.getSystemState();
+        int len = -1;
+        switch (argTypes[idx]) {
+          case Types.T_LONG:
+          case Types.T_DOUBLE:
+            len = 64;
+            break;
+          case Types.T_BOOLEAN:
+            len = 1;
+            break;
+          // cannot handle arrays and object parameters properly now
+          case Types.T_ARRAY:
+          case Types.T_REFERENCE:
+          case Types.T_INT:
+          case Types.T_FLOAT:
+            len = 32;
+            break;
+          case Types.T_SHORT:
+            len = 16;
+            break;
+          case Types.T_BYTE:
+          case Types.T_CHAR:
+            len = 8;
+            break;
+        }
+        if (!ti.isFirstStepInsn()) {
+          IntChoiceGenerator cg = new IntIntervalGenerator(key, 0, binomial[len][nBit]-1);
+          if (ss.setNextChoiceGenerator(cg)) {
+            ti.skipInstruction(insnToExecute);
+          }
+        }
+        else {
+          IntChoiceGenerator cg = (IntChoiceGenerator) ss.getChoiceGenerator(key);
+          if (cg != null) {
+            int choice = cg.getNextChoice();
+            bitFlip(ti.getTopFrame(), offset, len, nBit, choice, key);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/gov/nasa/jpf/vm/StackFrame.java
+++ b/src/main/gov/nasa/jpf/vm/StackFrame.java
@@ -2266,6 +2266,18 @@ public abstract class StackFrame implements Cloneable {
     return getOperandAttr();
   }
   
+  /**
+   * inject the bit flip(s) in the operand stack
+   */
+  public void bitFlip (int off, int typeSize, long bitsToFlip) {
+    int top = getTopPos();
+    if (typeSize == 1) {
+      setLocalVariable(top-off, peek(off) ^ (int) bitsToFlip);
+    }
+    else {
+      setLongLocalVariable(top-off-1, peekLong(off) ^ bitsToFlip);
+    }
+  }
   
   // those set the local vars that are normally initialized from call arguments
   public abstract void setArgumentLocal (int idx, int value, Object attr);

--- a/src/main/gov/nasa/jpf/vm/Types.java
+++ b/src/main/gov/nasa/jpf/vm/Types.java
@@ -988,6 +988,59 @@ public class Types {
       return 1;
     }
   }
+
+  /**
+   * what would be the info size in bits
+   */
+  public static int getTypeSizeInBits (byte typeCategory) {
+    switch (typeCategory) {
+      case T_LONG:
+      case T_DOUBLE:
+        return 64;
+      case Types.T_BOOLEAN:
+        return 1;
+      case Types.T_ARRAY:
+      case Types.T_REFERENCE:
+      case Types.T_INT:
+      case Types.T_FLOAT:
+        return 32;
+      case Types.T_SHORT:
+      case Types.T_CHAR:
+        return 16;
+      case Types.T_BYTE:
+        return 8;
+    }
+
+    throw new JPFException("invalid type type category id: " + typeCategory);
+  }
+
+  public static int getTypeSizeInBits (String signature) {
+    switch (signature.charAt(0)) {
+      case 'V':
+        return 0;
+
+      case 'Z':
+        return 1;
+      case 'B':
+        return 8;
+
+      case 'S':
+      case 'C':
+        return 16;
+
+      case 'L':
+      case '[':
+      case 'F':
+      case 'I':
+        return 32;
+
+      case 'D':
+      case 'J':
+        return 64;
+    }
+
+    throw new JPFException("invalid type string: " + signature);
+  }
   
   public static String asTypeName (String type) {
     if (type.startsWith("[") || type.endsWith(";")) {

--- a/src/main/gov/nasa/jpf/vm/Verify.java
+++ b/src/main/gov/nasa/jpf/vm/Verify.java
@@ -179,7 +179,7 @@ public class Verify {
   /**
    * Adds a comment to the error trace, which will be printed and saved.
    */
-  public static void addComment (String s) {}
+  public native static void addComment (String s);
 
   /**
    * Backwards compatibility START
@@ -204,24 +204,24 @@ public class Verify {
     }
   }
 
-  public static void atLabel (String label) {}
+  public native static void atLabel (String label);
 
-  public static void atLabel (int label) {}
+  public native static void atLabel (int label);
 
   /**
    * Marks the beginning of an atomic block.
    * THIS IS EVIL, DON'T USE IT FOR OPTIMIZATION - THAT'S WHAT POR IS FOR!
    * (it's mostly here to support model classes that need to execute atomic)
    */
-  public static void beginAtomic () {}
+  public native static void beginAtomic ();
 
   /**
    * Marks the end of an atomic block.
    * EVIL - see beginAtomic()
    */
-  public static void endAtomic () {}
+  public native static void endAtomic ();
 
-  public static void boring (boolean cond) {}
+  public native static void boring (boolean cond);
 
   public static void busyWait (long duration) {
     // this gets only executed outside of JPF
@@ -250,17 +250,17 @@ public class Verify {
     }
   }
 
-  public static void ignoreIf (boolean cond) {}
+  public native static void ignoreIf (boolean cond);
 
-  public static void instrumentPoint (String label) {}
+  public native static void instrumentPoint (String label);
 
-  public static void instrumentPointDeep (String label) {}
+  public native static void instrumentPointDeep (String label);
 
-  public static void instrumentPointDeepRecur (String label, int depth) {}
+  public native static void instrumentPointDeepRecur (String label, int depth);
 
-  public static void interesting (boolean cond) {}
+  public native static void interesting (boolean cond);
 
-  public static void breakTransition (String reason) {}
+  public native static void breakTransition (String reason);
 
  /** for testing and debugging purposes */
   public static int breakTransition (String reason, int min, int max) {
@@ -271,8 +271,8 @@ public class Verify {
    * simple debugging aids to imperatively print the current path output of the SUT
    * (to be used with vm.path_output)
    */
-  public static void printPathOutput(String msg) {}
-  public static void printPathOutput(boolean cond, String msg) {}
+  public native static void printPathOutput(String msg);
+  public native static void printPathOutput(boolean cond, String msg);
 
   public static void threadPrint (String s) {
     System.out.print( Thread.currentThread().getName());
@@ -322,32 +322,78 @@ public class Verify {
    */
   
   //--- use these if you know there are single attributes
-  public static void setFieldAttribute (Object o, String fieldName, int val) {}
-  public static int getFieldAttribute (Object o, String fieldName) { return 0; }
+  public native static void setFieldAttribute (Object o, String fieldName, int val);
+  public native static int getFieldAttribute (Object o, String fieldName);
   
   //--- use these for multiple attributes
-  public static void addFieldAttribute (Object o, String fieldName, int val) {}
-  public static int[] getFieldAttributes (Object o, String fieldName) { return new int[0]; }
+  public native static void addFieldAttribute (Object o, String fieldName, int val);
+  public native static int[] getFieldAttributes (Object o, String fieldName);
 
-  public static void setLocalAttribute (String varName, int val) {}
-  public static int getLocalAttribute (String varName) { return 0; }
+  public native static void setLocalAttribute (String varName, int val);
+  public native static int getLocalAttribute (String varName);
 
-  public static void addLocalAttribute (String varName, int val) {}
-  public static int[] getLocalAttributes (String varName) { return new int[0]; }
+  public native static void addLocalAttribute (String varName, int val);
+  public native static int[] getLocalAttributes (String varName);
 
-  public static void setElementAttribute (Object arr, int idx, int val){}
-  public static int getElementAttribute (Object arr, int idx) { return 0; }
+  public native static void setElementAttribute (Object arr, int idx, int val);
+  public native static int getElementAttribute (Object arr, int idx);
   
-  public static void addElementAttribute (Object arr, int idx, int val){}
-  public static int[] getElementAttributes (Object arr, int idx) { return new int[0]; }
+  public native static void addElementAttribute (Object arr, int idx, int val);
+  public native static int[] getElementAttributes (Object arr, int idx);
 
-  public static void setObjectAttribute (Object o, int val) {}
-  public static int getObjectAttribute (Object o) { return 0; }
+  public native static void setObjectAttribute (Object o, int val);
+  public native static int getObjectAttribute (Object o);
   
-  public static void addObjectAttribute (Object o, int val) {}
-  public static int[] getObjectAttributes (Object o) { return new int[0]; }
+  public native static void addObjectAttribute (Object o, int val);
+  public native static int[] getObjectAttributes (Object o);
 
-  
+
+  /**
+   * a bit flip generator that returns variable v with nBit bits flipped in v's lowest len bits
+   * note that the JPF does not execute the following getBitFlip methods, but execute their native methods
+   */
+  public native static long getBitFlip (long v, int nBit, int len);
+
+  /**
+   * flip nBit bits of a long variable
+   */
+  public native static long getBitFlip (long v, int nBit);
+
+  /**
+   * flip nBit bits of an int variable
+   */
+  public native static int getBitFlip (int v, int nBit);
+
+  /**
+   * flip nBit bits of a short variable
+   */
+  public native static short getBitFlip (short v, int nBit);
+
+  /**
+   * flip nBit bits of a char variable
+   */
+  public native static char getBitFlip (char v, int nBit);
+
+  /**
+   * flip nBit bits of a byte variable
+   */
+  public native static byte getBitFlip (byte v, int nBit);
+
+  /**
+   * flip nBit bits of a double variable
+   */
+  public native static double getBitFlip (double v, int nBit);
+
+  /**
+   * flip nBit bits of a float variable
+   */
+  public native static float getBitFlip (float v, int nBit);
+
+  /**
+   * flip a boolean variable
+   */
+  public native static boolean getBitFlip (boolean v);
+
   /**
    * this is the new boolean choice generator. Since there's no real
    * heuristic involved with boolean values, we skip the id (it's a
@@ -494,9 +540,7 @@ public class Verify {
     return false;
   }
 
-  public static void storeTrace (String fileName, String comment) {
-    // intercepted in NativePeer
-  }
+  public native static void storeTrace (String fileName, String comment);
 
   public static void storeTraceIf (boolean cond, String fileName, String comment) {
     if (cond) {
@@ -524,39 +568,26 @@ public class Verify {
     return false; // native
   }
   
-  public static void setShared (Object o, boolean isShared) {
-    // native
-  }
+  public native static void setShared (Object o, boolean isShared);
   
-  public static void freezeSharedness (Object o, boolean freeze) {
-    // native
-  }
+  public native static void freezeSharedness (Object o, boolean freeze);
   
-  public static void terminateSearch () {
-    // native
-  }
+  public native static void terminateSearch ();
 
-  public static void setHeuristicSearchValue (int n){
-    // native - to control UserHeuristic
-  }
+  // to control UserHeuristic
+  public native static void setHeuristicSearchValue (int n);
 
-  public static void resetHeuristicSearchValue (){
-    // native - to control UserHeuristic
-  }
+  // to control UserHeuristic
+  public native static void resetHeuristicSearchValue ();
 
-  public static int getHeuristicSearchValue (){
-    // native - to control UserHeuristic
-    return 0;
-  }
+  // to control UserHeuristic
+  public native static int getHeuristicSearchValue ();
 
   public static void setProperties (String... p) {
     // native
   }
 
-  public static String getProperty (String key) {
-    // native
-    return null;
-  }
+  public native static String getProperty (String key);
 
   public static <T> T createFromJSON(Class<T> clazz, String json){
     return null;

--- a/src/tests/fault/injection/examples/BCDEncodedISBNTest.java
+++ b/src/tests/fault/injection/examples/BCDEncodedISBNTest.java
@@ -1,0 +1,48 @@
+package fault.injection.examples;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class BCDEncodedISBNTest {
+    @Test
+    public void test10InvalidLength () {
+        long digits = 0x82749173801l;
+        assertTrue(!BCDEncodedISBN.check10(digits));
+    }
+    @Test
+    public void test10InvalidDigit () {
+        long digits = 0xb616046030l;
+        assertTrue(!BCDEncodedISBN.check10(digits));
+    }
+    @Test
+    public void test10Negative () {
+        long digits = 0x5516046030l;
+        assertTrue(!BCDEncodedISBN.check10(digits));
+    }
+    @Test
+    public void test10Positive () {
+        long digits = 0x2516046030l;
+        assertTrue(BCDEncodedISBN.check10(digits));
+    }
+    @Test
+    public void test13InvalidLength () {
+        long digits = 0x193972993818233l;
+        assertTrue(!BCDEncodedISBN.check13(digits));
+    }
+    @Test
+    public void test13InvalidDigit () {
+        long digits = 0x751604603077al;
+        assertTrue(!BCDEncodedISBN.check13(digits));
+    }
+    @Test
+    public void test13Negative () {
+        long digits = 0x7516046630879l;
+        assertTrue(!BCDEncodedISBN.check13(digits));
+    }
+    @Test
+    public void test13Positive () {
+        long digits = 0x7516046030879l;
+        assertTrue(BCDEncodedISBN.check13(digits));
+    }
+}

--- a/src/tests/fault/injection/examples/CRCTest.java
+++ b/src/tests/fault/injection/examples/CRCTest.java
@@ -1,0 +1,30 @@
+package fault.injection.examples;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CRCTest {
+    CRC crc;
+    @Test(expected = AssertionError.class)
+    public void testIllegal () {
+        crc = new CRC("102");
+    }
+    @Test
+    public void testNull () {
+        crc = new CRC("101");
+        assertTrue(!crc.check(null, null));
+    }
+    @Test
+    public void testPositive () {
+        crc = new CRC("1011");
+        assertTrue(crc.check("11010011101100", "100"));
+    }
+    @Test
+    public void testNegative () {
+        crc = new CRC("1011");
+        assertTrue(!crc.check("11010011101100", "101"));
+        assertTrue(!crc.check("11010011101100", "200"));
+        assertTrue(!crc.check("11010011101100", null));
+    }
+}

--- a/src/tests/fault/injection/examples/CheckISBNTest.java
+++ b/src/tests/fault/injection/examples/CheckISBNTest.java
@@ -1,0 +1,56 @@
+package fault.injection.examples;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class CheckISBNTest {
+    @Test
+    public void test10Null () {
+        assertTrue(!CheckISBN.check10(null));
+    }
+    @Test
+    public void test10InvalidLength () {
+        int[] digits = new int[8];
+        assertTrue(!CheckISBN.check10(digits));
+    }
+    @Test
+    public void test10InvalidDigit () {
+        int[] digits = {0, 3, 0, 6, 4, 0, 6, 1, 6, 11};
+        assertTrue(!CheckISBN.check10(digits));
+    }
+    @Test
+    public void test10Negative () {
+        int[] digits = {0, 3, 0, 6, 4, 0, 6, 1, 5, 5};
+        assertTrue(!CheckISBN.check10(digits));
+    }
+    @Test
+    public void test10Positive () {
+        int[] digits = {0, 3, 0, 6, 4, 0, 6, 1, 5, 2};
+        assertTrue(CheckISBN.check10(digits));
+    }
+    @Test
+    public void test13Null () {
+        assertTrue(!CheckISBN.check13(null));
+    }
+    @Test
+    public void test13InvalidLength () {
+        int[] digits = new int[20];
+        assertTrue(!CheckISBN.check13(digits));
+    }
+    @Test
+    public void test13InvalidDigit () {
+        int[] digits = {10, 7, 7, 0, 3, 0, 6, 4, 0, 6, 1, 5, 7};
+        assertTrue(!CheckISBN.check13(digits));
+    }
+    @Test
+    public void test13Negative () {
+        int[] digits = {9, 7, 8, 0, 3, 6, 6, 4, 0, 6, 1, 5, 7};
+        assertTrue(!CheckISBN.check13(digits));
+    }
+    @Test
+    public void test13Positive () {
+        int[] digits = {9, 7, 8, 0, 3, 0, 6, 4, 0, 6, 1, 5, 7};
+        assertTrue(CheckISBN.check13(digits));
+    }
+}

--- a/src/tests/fault/injection/examples/LongEncodedCRCTest.java
+++ b/src/tests/fault/injection/examples/LongEncodedCRCTest.java
@@ -1,0 +1,19 @@
+package fault.injection.examples;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class LongEncodedCRCTest {
+    LongEncodedCRC crc;
+    @Test
+    public void testPositive () {
+        crc = new LongEncodedCRC("1011");
+        assertTrue(crc.check(14, 0b11010011101100100l));
+    }
+    @Test
+    public void testNegative () {
+        crc = new LongEncodedCRC("1011");
+        assertTrue(!crc.check(14, 0b11010011101100101l));
+    }
+}

--- a/src/tests/gov/nasa/jpf/test/mc/data/BitFlipTest.java
+++ b/src/tests/gov/nasa/jpf/test/mc/data/BitFlipTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.mc.data;
+
+import gov.nasa.jpf.annotation.BitFlip;
+import gov.nasa.jpf.util.test.TestJPF;
+import gov.nasa.jpf.vm.Verify;
+
+import org.junit.Test;
+
+/**
+ * regression test for getBitFlip API and BitFlipListener
+ */
+public class BitFlipTest extends TestJPF {
+
+  public static int fooStatic(@BitFlip int bar) {
+    return bar;
+  }
+
+  public int fooInstance(@BitFlip int bar) {
+    return bar;
+  }
+
+  public static void main(String[] args) {
+    runTestsOfThisClass(args);
+  }
+
+  @Test
+  public void testStaticMethodParameterBitFlip() {
+
+    if (!isJPFRun()){
+      Verify.resetCounter(0);
+    }
+
+    if (verifyNoPropertyViolation("+listener=gov.nasa.jpf.listener.BitFlipListener")){
+      System.out.println("@BitFlip annotation for static method parameters test");
+      int d = fooStatic(0);
+      System.out.print("d = ");
+      System.out.println(d);
+      int seen = Verify.getCounter(0);
+      seen |= d;
+      Verify.setCounter(0, seen);
+    } else {
+      assert Verify.getCounter(0) == -1;
+    }
+  }
+
+  @Test
+  public void testInstanceMethodParameterBitFlip() {
+
+    if (!isJPFRun()){
+      Verify.resetCounter(0);
+    }
+
+    if (verifyNoPropertyViolation("+listener=gov.nasa.jpf.listener.BitFlipListener")){
+      System.out.println("@BitFlip annotation for instance method parameters test");
+      int d = fooInstance(0);
+      System.out.print("d = ");
+      System.out.println(d);
+      int seen = Verify.getCounter(0);
+      seen |= d;
+      Verify.setCounter(0, seen);
+    } else {
+      assert Verify.getCounter(0) == -1;
+    }
+  }
+
+  @Test
+  public void testBitFlipAPI() {
+
+    if (!isJPFRun()){
+      Verify.resetCounter(0);
+    }
+
+    if (verifyNoPropertyViolation()){
+      System.out.println("getBitFlip API test");
+      int d = Verify.getBitFlip(0, 1);
+      System.out.print("d = ");
+      System.out.println(d);
+      int seen = Verify.getCounter(0);
+      seen |= d;
+      Verify.setCounter(0, seen);
+    } else {
+      assert Verify.getCounter(0) == -1;
+    }
+  }
+}


### PR DESCRIPTION
#297 refactors `Verify.java` to resolve a bug introduced by #295
#299 refactors `Verify.java` to have native qualifiers instead of empty method bodies for multiple methods

Five test classes have been added in as a result of the patch which add a total of 27 tests:
1. `BCDEncodedISBNTest.java`
2. `CRCTest.java`
3. `CheckISBNTest.java`
4. `LongEncodedCRCTest.java`
5. `BitFlipTest.java`

Thanks!
