### PR TITLE
Apply patch for #296, to add maven-publish plugin support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,7 @@ publishing {
             url = "https://plugins.gradle.org/m2/"
         }
     }
+}
     
 def PolDetJPFClasspath = "${buildDir}/tests:" + configurations.testRuntimeClasspath.findAll { it.name.endsWith('jar') && (it.name.contains('junit') || it.name.contains('hamcrest')) }.join(":")
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'maven-publish'
 }
 
 java {
@@ -272,6 +273,31 @@ test {
                                  "${result.skippedTestCount} skipped"]
 
             println "Summary: " + summaryFields.join(", ")
+        }
+    }
+}
+
+publishing {
+    publications {
+        jpfCore(MavenPublication) {
+            groupId = 'gov.nasa'
+            artifactId = 'jpf-core'
+            artifact createJpfJar
+        }
+        jpfAnnotation(MavenPublication) {
+            groupId = 'gov.nasa'
+            artifactId = 'jpf-annotations'
+            artifact createAnnotationsJar
+        }
+        jpfClasses(MavenPublication) {
+            groupId = 'gov.nasa'
+            artifactId = 'jpf-classes'
+            artifact createJpfClassesJar
+        }
+    }
+    repositories {
+        maven {
+            url = "https://plugins.gradle.org/m2/"
         }
     }
 }


### PR DESCRIPTION
'maven-publish' plugin is used to support publishing to the local maven repository.

No new tests added.

Thanks!