### PR TITLE
Apply patch for #171, to add support for java.nio.Buffer

### DIFF
--- a/src/classes/modules/java.base/java/nio/Buffer.java
+++ b/src/classes/modules/java.base/java/nio/Buffer.java
@@ -6,94 +6,95 @@
  * The Java Pathfinder core (jpf-core) platform is licensed under the
  * Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
- *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package java.nio;
 
 public abstract class Buffer {
 
-	protected int position;
-	protected int capacity;
-	protected int limit;
-	protected int mark = -1;
+  protected int position = 0;
+  protected int capacity;
+  protected int limit;
+  protected int mark = -1;
+  long address;
 
 
-	// Todo: There exists other missing methods in this class
-	// which may throw NoSuchMethodException errors to users
-	// For example checkBounds has yet to be implemented
-	Buffer(int mark, int pos, int lim, int cap) {
-		if (cap < 0)
-			throw new IllegalArgumentException("Negative capacity: " + cap);
-		this.capacity = cap;
-		limit(lim);
-		position(pos);
-		if (mark >= 0 && mark <= pos){
-			this.mark = mark;
-		}
-	}
+  // Todo: There exists other missing methods in this class
+  // which may throw NoSuchMethodException errors to users
+  // For example checkBounds has yet to be implemented
+  Buffer(int mark, int pos, int lim, int cap) {
+    if (cap < 0)
+      throw new IllegalArgumentException("Negative capacity: " + cap);
+    this.capacity = cap;
+    limit(lim);
+    position(pos);
+    if (mark >= 0 && mark <= pos){
+      this.mark = mark;
+    }
+  }
 
-	public final int capacity() {
-		return capacity;
-	}
+  public final int capacity() {
+    return capacity;
+  }
 
-	public final Buffer position(int newPosition) {
-		if ((newPosition<0)||(newPosition>limit)) {
-			throw new IllegalArgumentException("Illegal buffer position exception: "+newPosition);
-		}
-		this.position = newPosition;
-		return this;
-	}
+  public Buffer position(int newPosition) {
+    if ((newPosition<0)||(newPosition>limit)) {
+      throw new IllegalArgumentException("Illegal buffer position exception: "+newPosition);
+    }
+    this.position = newPosition;
+    return this;
+  }
 
-	public final int position() {
-		return position;
-	}
+  public final int position() {
+    return position;
+  }
 
-	public final int limit() {
-		return this.limit;
-	}
+  public int limit() {
+    return this.limit;
+  }
 
-	public final Buffer limit(int newLimit) {
-		if ((newLimit<0)||(newLimit>capacity)) {
-			throw new IllegalArgumentException("Illegal buffer limit exception: "+newLimit);
-		}
-		this.limit = newLimit;
-		return this;
-	}
+  public Buffer limit(int newLimit) {
+    if ((newLimit<0)||(newLimit>capacity)) {
+      throw new IllegalArgumentException("Illegal buffer limit exception: "+newLimit);
+    }
+    this.limit = newLimit;
+    return this;
+  }
 
-	public final Buffer clear(){
-		position = 0;
-		limit = capacity;
-		mark = -1;
-		return this;
-	}
+  public final Buffer clear(){
+    position = 0;
+    limit = capacity;
+    mark = -1;
+    return this;
+  }
 
-	public final Buffer flip() {
-		limit = position;
-		position = 0;
-		return this;
-	}
+  public Buffer flip() {
+    limit = position;
+    position = 0;
+    return this;
+  }
 
-	public final Buffer rewind() {
-		position = 0;
-		return this;
-	}
+  public final Buffer rewind() {
+    position = 0;
+    return this;
+  }
 
-	public final int remaining() {
-		return limit-position;
-	}
+  public final int remaining() {
+    return limit-position;
+  }
 
-	public final boolean hasRemaining() {
-		return remaining()>0;
-	}
+  public final boolean hasRemaining() {
+    return remaining()>0;
+  }
 
-	public abstract boolean hasArray();
+  public abstract boolean hasArray();
 
-	public abstract Object array();
+  public abstract Object array();
 }

--- a/src/classes/modules/java.base/java/nio/Buffer.java
+++ b/src/classes/modules/java.base/java/nio/Buffer.java
@@ -18,9 +18,26 @@
 package java.nio;
 
 public abstract class Buffer {
+
 	protected int position;
 	protected int capacity;
 	protected int limit;
+	protected int mark = -1;
+
+
+	// Todo: There exists other missing methods in this class
+	// which may throw NoSuchMethodException errors to users
+	// For example checkBounds has yet to be implemented
+	Buffer(int mark, int pos, int lim, int cap) {
+		if (cap < 0)
+			throw new IllegalArgumentException("Negative capacity: " + cap);
+		this.capacity = cap;
+		limit(lim);
+		position(pos);
+		if (mark >= 0 && mark <= pos){
+			this.mark = mark;
+		}
+	}
 
 	public final int capacity() {
 		return capacity;
@@ -53,6 +70,7 @@ public abstract class Buffer {
 	public final Buffer clear(){
 		position = 0;
 		limit = capacity;
+		mark = -1;
 		return this;
 	}
 

--- a/src/classes/modules/java.base/java/nio/ByteBuffer.java
+++ b/src/classes/modules/java.base/java/nio/ByteBuffer.java
@@ -6,288 +6,314 @@
  * The Java Pathfinder core (jpf-core) platform is licensed under the
  * Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
- *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and 
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package java.nio;
 
 public class ByteBuffer extends Buffer {
-	byte[] array;
-	int offset;
+  byte[] array;
+  int offset;
 
-	public static ByteBuffer allocate(int i) {
-		if (i < 0) {
-			throw new IllegalArgumentException();
-		}
-		ByteBuffer newBuffer = new ByteBuffer(-1, 0, i, i, new byte[i], 0);
-		return newBuffer;
-	}
+  public static ByteBuffer allocate(int i) {
+    if (i < 0) {
+      throw new IllegalArgumentException();
+    }
+    ByteBuffer newBuffer = new ByteBuffer(-1, 0, i, i, new byte[i], 0);
+    return newBuffer;
+  }
 
-	public static ByteBuffer allocateDirect(int capacity) {
-		return allocate(capacity);
-	}
+  public static ByteBuffer allocateDirect(int capacity) {
+    return allocate(capacity);
+  }
 
-	ByteBuffer(int mark, int pos, int lim, int cap, byte[] hb, int offset) {
-		super(mark, pos, lim, cap);
-		this.array = hb;
-		this.offset = offset;
-	}
+  ByteBuffer(int mark, int pos, int lim, int cap, byte[] hb, int offset) {
+    super(mark, pos, lim, cap);
+    this.array = hb;
+    this.offset = offset;
+  }
 
-	ByteBuffer(int mark, int pos, int lim, int cap) {
-		this(mark, pos, lim, cap, null, 0);
-	}
+  ByteBuffer(int mark, int pos, int lim, int cap) {
+    this(mark, pos, lim, cap, null, 0);
+  }
 
-	public ByteBuffer duplicate() {
-		ByteBuffer copy = new ByteBuffer(-1, 0, capacity, capacity, new byte[capacity], 0);
-		copy.array = array;
-		return copy;
-	}
+  public ByteBuffer position(int newPosition) {
+    super.position(newPosition);
+    return this;
+  }
 
-	public ByteBuffer asReadOnlyBuffer() {
-		return duplicate();
-	}
+  public ByteBuffer duplicate() {
+    ByteBuffer copy = new ByteBuffer(-1, 0, capacity, capacity, new byte[capacity], 0);
+    copy.array = array;
+    return copy;
+  }
 
-	public ByteBuffer slice() {
-		int remaining = limit - position;
-		ByteBuffer copy = new ByteBuffer(-1, 0, remaining, remaining, new byte[remaining], 0);
-		copy.array = array;
-		return copy;
-	}
+  public ByteBuffer asReadOnlyBuffer() {
+    return duplicate();
+  }
 
-	public ByteBuffer put(byte b) {
-		if (position >= limit) {
-			throw new BufferOverflowException();
-		}
-		array[position] = b;
-		position++;
-		return this;
-	}
+  public ByteBuffer slice() {
+    int remaining = limit - position;
+    ByteBuffer copy = new ByteBuffer(-1, 0, remaining, remaining, new byte[remaining], 0);
+    copy.array = array;
+    return copy;
+  }
 
-	public ByteBuffer put(int i, byte b) {
-		if ((i < 0) || (i >= limit)) {
-			throw new IndexOutOfBoundsException();
-		}
-		array[i] = b;
-		return this;
-	}
+  public ByteBuffer put(byte b) {
+    if (position >= limit) {
+      throw new BufferOverflowException();
+    }
+    array[position] = b;
+    position++;
+    return this;
+  }
 
-	public ByteBuffer put(ByteBuffer src) {
-		if (src == this) {
-			throw new IllegalArgumentException();
-		}
+  public ByteBuffer put(int i, byte b) {
+    if ((i < 0) || (i >= limit)) {
+      throw new IndexOutOfBoundsException();
+    }
+    array[i] = b;
+    return this;
+  }
 
-		int srcRemaining = src.remaining();
-		if (srcRemaining > remaining()) {
-			throw new BufferOverflowException();
-		}
+  public ByteBuffer put(ByteBuffer src) {
+    if (src == this) {
+      throw new IllegalArgumentException();
+    }
 
-		System.arraycopy(src.array, src.position(), array, position, srcRemaining);
+    int srcRemaining = src.remaining();
+    if (srcRemaining > remaining()) {
+      throw new BufferOverflowException();
+    }
 
-		src.position(src.position() + srcRemaining);
-		position(position + srcRemaining);
+    System.arraycopy(src.array, src.position(), array, position, srcRemaining);
 
-		return this;
-	}
+    src.position(src.position() + srcRemaining);
+    position(position + srcRemaining);
 
-	public ByteBuffer put(byte[] bytes, int offset, int length) {
-		if ((offset | length | (offset + length) | (bytes.length - (offset + length))) < 0) {
-			throw new IndexOutOfBoundsException();
-		}
+    return this;
+  }
 
-		if (length > remaining()) {
-			throw new BufferOverflowException();
-		}
+  public ByteBuffer put(byte[] bytes, int offset, int length) {
+    if ((offset | length | (offset + length) | (bytes.length - (offset + length))) < 0) {
+      throw new IndexOutOfBoundsException();
+    }
 
-		System.arraycopy(bytes, offset, array, position, length);
-		position(position + length);
+    if (length > remaining()) {
+      throw new BufferOverflowException();
+    }
 
-		return this;
-	}
+    System.arraycopy(bytes, offset, array, position, length);
+    position(position + length);
 
-	public ByteBuffer put(byte[] bytes) {
-		return put(bytes, 0, bytes.length);
-	}
+    return this;
+  }
 
-	public byte get() {
-		if (position >= limit) {
-			throw new BufferUnderflowException();
-		}
-		position++;
-		return array[position-1];
-	}
+  public ByteBuffer put(byte[] bytes) {
+    return put(bytes, 0, bytes.length);
+  }
 
-	public byte get(int i) {
-		if ((i < 0) || (i >= limit)) {
-			throw new IndexOutOfBoundsException();
-		}
-		return array[i];
-	}
+  public byte get() {
+    if (position >= limit) {
+      throw new BufferUnderflowException();
+    }
+    position++;
+    return array[position-1];
+  }
 
-	public ByteBuffer get(byte[] bytes) {
-		return get(bytes, 0, bytes.length);
-	}
+  public byte get(int i) {
+    if ((i < 0) || (i >= limit)) {
+      throw new IndexOutOfBoundsException();
+    }
+    return array[i];
+  }
 
-	public ByteBuffer get(byte[] bytes, int offset, int length) {
-		if ((offset | length | (offset + length) | (bytes.length - (offset + length))) < 0) {
-			throw new IndexOutOfBoundsException();
-		}
+  public ByteBuffer get(byte[] bytes) {
+    return get(bytes, 0, bytes.length);
+  }
 
-		if (length > remaining()) {
-			throw new BufferUnderflowException();
-		}
+  public ByteBuffer get(byte[] bytes, int offset, int length) {
+    if ((offset | length | (offset + length) | (bytes.length - (offset + length))) < 0) {
+      throw new IndexOutOfBoundsException();
+    }
 
-		int end = offset + length;
-		for (int i = offset; i < end; i++) {
-			bytes[i] = get();
-		}
-		return this;
-	}
+    if (length > remaining()) {
+      throw new BufferUnderflowException();
+    }
 
-	public ByteBuffer order(ByteOrder order) {
-		return this;
-	}
+    int end = offset + length;
+    for (int i = offset; i < end; i++) {
+      bytes[i] = get();
+    }
+    return this;
+  }
 
-	/***************************************************************
-	 * public char getChar()
-	 * @return 16 bit (UTF-16) char of ByteBuffer at this.position 
-	 * Caution: 8 or 32 bit character encodings are not supported.
-	 */
-	public char getChar() {
-        char res=getChar(this.position);
-        this.position+=2;
-        return res;
-	}
+  public ByteBuffer order(ByteOrder order) {
+    return this;
+  }
 
-	/***************************************************************
-	 * public char getChar(int pos)
-	 * @return 16 bit (UTF-16) char of ByteBuffer at int pos 
-	 * Caution: 8 or 32 bit character encodings are not supported.
-	 */
-	public char getChar(int pos) {
-		if (limit - pos < 2) {
-			throw new BufferUnderflowException();
-		}
-		int x1 = (array[pos]   & 0xff) << 8;
-		int x0 = (array[pos+1] & 0xff);
+  /***************************************************************
+   * public char getChar()
+   * @return 16 bit (UTF-16) char of ByteBuffer at this.position
+   * Caution: 8 or 32 bit character encodings are not supported.
+   */
+  public char getChar() {
+    char res=getChar(this.position);
+    this.position+=2;
+    return res;
+  }
 
-		return (char) (x1 | x0);
-	}
+  /***************************************************************
+   * public char getChar(int pos)
+   * @return 16 bit (UTF-16) char of ByteBuffer at int pos
+   * Caution: 8 or 32 bit character encodings are not supported.
+   */
+  public char getChar(int pos) {
+    if (limit - pos < 2) {
+      throw new BufferUnderflowException();
+    }
+    int x1 = (array[pos]   & 0xff) << 8;
+    int x0 = (array[pos+1] & 0xff);
 
-	/***************************************************************
-	 * public ByteBuffer putChar(char c)
-	 * @return insert 16 bit (UTF-16) char c at this.position  
-	 * Caution: 8 or 32 bit character encodings are not supported.
-	 */
-	public ByteBuffer putChar(char c) {
-		if (limit - position < 2) {
-			throw new BufferOverflowException();
-		}
-		array[position]   = (byte)(c >> 8);
-		array[position+1] = (byte)(c     );
-		position += 2;
+    return (char) (x1 | x0);
+  }
 
-		return this;
-	}
+  /***************************************************************
+   * public ByteBuffer putChar(char c)
+   * @return insert 16 bit (UTF-16) char c at this.position
+   * Caution: 8 or 32 bit character encodings are not supported.
+   */
+  public ByteBuffer putChar(char c) {
+    if (limit - position < 2) {
+      throw new BufferOverflowException();
+    }
+    array[position]   = (byte)(c >> 8);
+    array[position+1] = (byte)(c     );
+    position += 2;
 
-	public int getInt() {
-		if (limit - position < 4) {
-			throw new BufferUnderflowException();
-		}
+    return this;
+  }
 
-		int x3 = (array[position  ]       ) << 24;
-		int x2 = (array[position+1] & 0xff) << 16;
-		int x1 = (array[position+2] & 0xff) <<  8;
-		int x0 = (array[position+3] & 0xff);
-		position += 4;
+  public int getInt() {
+    if (limit - position < 4) {
+      throw new BufferUnderflowException();
+    }
 
-		return (x3 | x2 | x1 | x0);
-	}
+    int x3 = (array[position  ]       ) << 24;
+    int x2 = (array[position+1] & 0xff) << 16;
+    int x1 = (array[position+2] & 0xff) <<  8;
+    int x0 = (array[position+3] & 0xff);
+    position += 4;
 
-	public ByteBuffer putInt(int x) {
-		if (limit - position < 4) {
-			throw new BufferOverflowException();
-		}
+    return (x3 | x2 | x1 | x0);
+  }
 
-		array[position  ] = (byte)(x >> 24);
-		array[position+1] = (byte)(x >> 16);
-		array[position+2] = (byte)(x >>  8);
-		array[position+3] = (byte)(x      );
-		position += 4;
+  public ByteBuffer putInt(int x) {
+    if (limit - position < 4) {
+      throw new BufferOverflowException();
+    }
 
-		return this;
-	}
+    array[position  ] = (byte)(x >> 24);
+    array[position+1] = (byte)(x >> 16);
+    array[position+2] = (byte)(x >>  8);
+    array[position+3] = (byte)(x      );
+    position += 4;
 
-	public long getLong() {
-		if (limit - position < 8) {
-			throw new BufferUnderflowException();
-		}
+    return this;
+  }
 
-		long x7 = ((long)(array[position  ]       ) << 56);
-		long x6 = ((long)(array[position+1] & 0xff) << 48);
-		long x5 = ((long)(array[position+2] & 0xff) << 40);
-		long x4 = ((long)(array[position+3] & 0xff) << 32);
-		long x3 = ((long)(array[position+4] & 0xff) << 24);
-		long x2 = ((long)(array[position+5] & 0xff) << 16);
-		long x1 = ((long)(array[position+6] & 0xff) <<  8);
-		long x0 = (array[position+7] & 0xff      );
-		position += 8;
+  public long getLong() {
+    if (limit - position < 8) {
+      throw new BufferUnderflowException();
+    }
 
-		return (x7 | x6 | x5 | x4 | x3 | x2 | x1 | x0);
-	}
+    long x7 = ((long)(array[position  ]       ) << 56);
+    long x6 = ((long)(array[position+1] & 0xff) << 48);
+    long x5 = ((long)(array[position+2] & 0xff) << 40);
+    long x4 = ((long)(array[position+3] & 0xff) << 32);
+    long x3 = ((long)(array[position+4] & 0xff) << 24);
+    long x2 = ((long)(array[position+5] & 0xff) << 16);
+    long x1 = ((long)(array[position+6] & 0xff) <<  8);
+    long x0 = (array[position+7] & 0xff      );
+    position += 8;
 
-	public ByteBuffer putLong(long x) {
-		if (limit - position < 8) {
-			throw new BufferOverflowException();
-		}
+    return (x7 | x6 | x5 | x4 | x3 | x2 | x1 | x0);
+  }
 
-		array[position  ] = (byte)((x >> 56)       );
-		array[position+1] = (byte)((x >> 48) & 0xff);
-		array[position+2] = (byte)((x >> 40) & 0xff);
-		array[position+3] = (byte)((x >> 32) & 0xff);
-		array[position+4] = (byte)((x >> 24) & 0xff);
-		array[position+5] = (byte)((x >> 16) & 0xff);
-		array[position+6] = (byte)((x >>  8) & 0xff);
-		array[position+7] = (byte)((x      ) & 0xff);
-		position += 8;
+  public ByteBuffer putLong(long x) {
+    if (limit - position < 8) {
+      throw new BufferOverflowException();
+    }
 
-		return this;
-	}
+    array[position  ] = (byte)((x >> 56)       );
+    array[position+1] = (byte)((x >> 48) & 0xff);
+    array[position+2] = (byte)((x >> 40) & 0xff);
+    array[position+3] = (byte)((x >> 32) & 0xff);
+    array[position+4] = (byte)((x >> 24) & 0xff);
+    array[position+5] = (byte)((x >> 16) & 0xff);
+    array[position+6] = (byte)((x >>  8) & 0xff);
+    array[position+7] = (byte)((x      ) & 0xff);
+    position += 8;
 
-	@Override
-	public byte[] array() {
-		return array;
-	}
+    return this;
+  }
 
-	@Override
-	public boolean hasArray() {
-		return true;
-	}
+  @Override
+  public byte[] array() {
+    return array;
+  }
 
-	public ByteBuffer compact() {
-		int pos = position();
-		int lim = limit();
-		int cap = capacity();
-		int rem = lim - pos;
+  @Override
+  public boolean hasArray() {
+    return true;
+  }
 
-		byte[] newArray = new byte[cap];
-		System.arraycopy(array, pos, newArray, 0, rem);
-		array = newArray;
+  public ByteBuffer compact() {
+    int pos = position();
+    int lim = limit();
+    int cap = capacity();
+    int rem = lim - pos;
 
-		position(rem);
-		limit(cap);
-		return this;
-	}
+    byte[] newArray = new byte[cap];
+    System.arraycopy(array, pos, newArray, 0, rem);
+    array = newArray;
 
-	public static ByteBuffer wrap(byte[] outMess) {
-		ByteBuffer byteBuffer = new ByteBuffer(-1, 0, outMess.length, outMess.length, new byte[outMess.length], 0);
-		byteBuffer.clear();
-		System.arraycopy(outMess, 0 , byteBuffer.array, 0, outMess.length);
-		return byteBuffer;
-	}
+    position(rem);
+    limit(cap);
+    return this;
+  }
+
+  public static ByteBuffer wrap(byte[] outMess) {
+    ByteBuffer byteBuffer = new ByteBuffer(-1, 0, outMess.length, outMess.length, new byte[outMess.length], 0);
+    byteBuffer.clear();
+    System.arraycopy(outMess, 0 , byteBuffer.array, 0, outMess.length);
+    return byteBuffer;
+  }
+
+  public boolean equals(Object ob) {
+    if (this == ob)
+      return true;
+    if (!(ob instanceof ByteBuffer))
+      return false;
+    ByteBuffer that = (ByteBuffer)ob;
+    int thisPos = this.position();
+    int thisRem = this.limit() - thisPos;
+    int thatPos = that.position();
+    int thatRem = that.limit() - thatPos;
+    if (thisRem < 0 || thisRem != thatRem)
+      return false;
+    return BufferMismatch.mismatch(this, thisPos,
+        that, thatPos,
+        thisRem) < 0;
+  }
+
+  Object base() {
+    return array;
+  }
 }

--- a/src/classes/modules/java.base/java/nio/ByteBuffer.java
+++ b/src/classes/modules/java.base/java/nio/ByteBuffer.java
@@ -19,12 +19,13 @@ package java.nio;
 
 public class ByteBuffer extends Buffer {
 	byte[] array;
+	int offset;
 
 	public static ByteBuffer allocate(int i) {
 		if (i < 0) {
 			throw new IllegalArgumentException();
 		}
-		ByteBuffer newBuffer = new ByteBuffer(i);
+		ByteBuffer newBuffer = new ByteBuffer(-1, 0, i, i, new byte[i], 0);
 		return newBuffer;
 	}
 
@@ -32,14 +33,18 @@ public class ByteBuffer extends Buffer {
 		return allocate(capacity);
 	}
 
-	protected ByteBuffer(int i) {
-		capacity = i;
-		this.clear();
-		array = new byte[i];
+	ByteBuffer(int mark, int pos, int lim, int cap, byte[] hb, int offset) {
+		super(mark, pos, lim, cap);
+		this.array = hb;
+		this.offset = offset;
+	}
+
+	ByteBuffer(int mark, int pos, int lim, int cap) {
+		this(mark, pos, lim, cap, null, 0);
 	}
 
 	public ByteBuffer duplicate() {
-		ByteBuffer copy = new ByteBuffer(capacity);
+		ByteBuffer copy = new ByteBuffer(-1, 0, capacity, capacity, new byte[capacity], 0);
 		copy.array = array;
 		return copy;
 	}
@@ -50,7 +55,7 @@ public class ByteBuffer extends Buffer {
 
 	public ByteBuffer slice() {
 		int remaining = limit - position;
-		ByteBuffer copy = new ByteBuffer(remaining);
+		ByteBuffer copy = new ByteBuffer(-1, 0, remaining, remaining, new byte[remaining], 0);
 		copy.array = array;
 		return copy;
 	}
@@ -280,7 +285,7 @@ public class ByteBuffer extends Buffer {
 	}
 
 	public static ByteBuffer wrap(byte[] outMess) {
-		ByteBuffer byteBuffer = new ByteBuffer(outMess.length);
+		ByteBuffer byteBuffer = new ByteBuffer(-1, 0, outMess.length, outMess.length, new byte[outMess.length], 0);
 		byteBuffer.clear();
 		System.arraycopy(outMess, 0 , byteBuffer.array, 0, outMess.length);
 		return byteBuffer;

--- a/src/classes/modules/java.base/java/nio/CharBuffer.java
+++ b/src/classes/modules/java.base/java/nio/CharBuffer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package java.nio;
+
+public class CharBuffer extends Buffer {
+
+  char[] array;
+  int offset;
+
+  CharBuffer(int mark, int pos, int lim, int cap, char[] hb, int offset) {
+    super(mark, pos, lim, cap);
+    this.array = hb;
+    this.offset = offset;
+  }
+
+  CharBuffer(int mark, int pos, int lim, int cap) {
+    this(mark, pos, lim, cap, null, 0);
+  }
+
+  public static CharBuffer allocate(int i) {
+    if (i < 0) {
+      throw new IllegalArgumentException();
+    }
+    CharBuffer newBuffer = new CharBuffer(-1, 0, i, i, new char[i], 0);
+    return newBuffer;
+  }
+
+  public CharBuffer put(char c) {
+    if (position >= limit) {
+      throw new BufferOverflowException();
+    }
+    array[position] = c;
+    position++;
+    return this;
+  }
+
+  public CharBuffer put(int i, char c) {
+    if ((i < 0) || (i >= limit)) {
+      throw new IndexOutOfBoundsException();
+    }
+    array[i] = c;
+    return this;
+  }
+
+  public CharBuffer put(String src, int start, int end) {
+    if(end - start > remaining()) {
+      throw new BufferOverflowException();
+    }
+    for(int i=start; i<end; i++) {
+      return this.put(src.charAt(i));
+    }
+    return this;
+  }
+
+  public final CharBuffer put(String src) {
+    return put(src, 0, src.length());
+  }
+
+  public char get() {
+    if (position >= limit) {
+      throw new BufferUnderflowException();
+    }
+    position++;
+    return array[position-1];
+  }
+
+  public static CharBuffer wrap(CharSequence outMess) {
+    CharBuffer charBuffer = new CharBuffer(-1, 0, outMess.length(), outMess.length(), new char[outMess.length()], 0);
+    charBuffer.clear();
+    for(int i=0; i< outMess.length(); i++) {
+      charBuffer.put(outMess.charAt(i));
+    }
+    charBuffer.flip();
+    return charBuffer;
+  }
+
+  @Override
+  public char[] array() {
+    return array;
+  }
+
+  @Override
+  public boolean hasArray() {
+    return true;
+  }
+
+  public final int length() {
+    return remaining();
+  }
+
+  @Override
+  public final CharBuffer limit(int newLimit) {
+    super.limit(newLimit);
+    return this;
+  }
+
+  @Override
+  public final CharBuffer flip() {
+    super.flip();
+    return this;
+  }
+
+}

--- a/src/classes/modules/java.base/java/text/NumberFormat.java
+++ b/src/classes/modules/java.base/java/text/NumberFormat.java
@@ -18,6 +18,8 @@
 
 package java.text;
 
+import java.util.Locale;
+
 public abstract class NumberFormat extends Format {
 
   static final int INTEGER_STYLE=0;
@@ -28,6 +30,10 @@ public abstract class NumberFormat extends Format {
   }
   
   public static NumberFormat getNumberInstance() {
+    return new DecimalFormat(NUMBER_STYLE);
+  }
+
+  public static NumberFormat getNumberInstance(Locale locale) {
     return new DecimalFormat(NUMBER_STYLE);
   }
 

--- a/src/classes/modules/java.base/java/util/regex/Matcher.java
+++ b/src/classes/modules/java.base/java/util/regex/Matcher.java
@@ -92,6 +92,13 @@ public class Matcher {
 
   public native Matcher useAnchoringBounds(boolean b);
 
+  public Matcher usePattern(Pattern newPattern){
+    this.pattern = newPattern;
+    return updatePattern();
+  }
+
+  public native Matcher updatePattern();
+
   public native int regionStart();
 
   public native int regionEnd();

--- a/src/classes/modules/java.base/java/util/regex/Pattern.java
+++ b/src/classes/modules/java.base/java/util/regex/Pattern.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License.
  */
-
 package java.util.regex;
 
 /**
@@ -61,5 +60,24 @@ public class Pattern {
   @Override
   public String toString() {
     return regex;
+  }
+
+  public static String quote(String s) {
+    int slashEIndex = s.indexOf("\\E");
+    if (slashEIndex == -1)
+      return "\\Q" + s + "\\E";
+
+    StringBuilder sb = new StringBuilder(s.length() * 2);
+    sb.append("\\Q");
+    slashEIndex = 0;
+    int current = 0;
+    while ((slashEIndex = s.indexOf("\\E", current)) != -1) {
+      sb.append(s.substring(current, slashEIndex));
+      current = slashEIndex + 2;
+      sb.append("\\E\\\\E\\Q");
+    }
+    sb.append(s.substring(current, s.length()));
+    sb.append("\\E");
+    return sb.toString();
   }
 }

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_util_regex_Matcher.java
@@ -39,6 +39,16 @@ public class JPF_java_util_regex_Matcher extends NativePeer {
     matchers = new HashMap<Integer,Matcher>();
   }
 
+  Pattern getPatternFromMatcher(MJIEnv env, int objref) {
+    int patRef = env.getReferenceField(objref, "pattern");
+
+    int regexRef = env.getReferenceField(patRef, "regex");
+    String regex = env.getStringObject(regexRef);
+    int flags = env.getIntField(patRef, "flags");
+
+    return Pattern.compile(regex, flags);
+  }
+
   void putInstance (MJIEnv env, int objref, Matcher matcher) {
     int id = env.getIntField(objref,  "id");
     matchers.put(id, matcher);
@@ -52,13 +62,7 @@ public class JPF_java_util_regex_Matcher extends NativePeer {
   
   @MJI
   public void register____V (MJIEnv env, int objref) {
-    int patRef = env.getReferenceField(objref, "pattern");
-    
-    int regexRef = env.getReferenceField(patRef, "regex");
-    String regex = env.getStringObject(regexRef);
-    int flags = env.getIntField(patRef, "flags");
-    
-    Pattern pat = Pattern.compile(regex, flags);
+    Pattern pat = getPatternFromMatcher(env, objref);
 
     int inputRef = env.getReferenceField(objref, "input");
     String input = env.getStringObject(inputRef);
@@ -203,6 +207,19 @@ public class JPF_java_util_regex_Matcher extends NativePeer {
   public int useAnchoringBounds__Z__Ljava_util_regex_Matcher_2(MJIEnv env, int objref, boolean b) {
     Matcher matcher = getInstance(env, objref);
     matcher = matcher.useAnchoringBounds(b);
+    putInstance(env, objref, matcher);
+
+    return objref;
+  }
+
+  @MJI
+  public int updatePattern____Ljava_util_regex_Matcher_2(MJIEnv env, int objref) {
+    //We get the newly updated pattern
+    Pattern pat = getPatternFromMatcher(env, objref);
+
+    //We update the matcher with the new pattern
+    Matcher matcher = getInstance(env, objref);
+    matcher = matcher.usePattern(pat);
     putInstance(env, objref, matcher);
 
     return objref;

--- a/src/tests/gov/nasa/jpf/test/java/nio/BufferTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/nio/BufferTest.java
@@ -15,30 +15,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package gov.nasa.jpf.test.java.nio;
 
 import gov.nasa.jpf.util.test.TestJPF;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.Scanner;
 
-public class ByteBufferTest extends TestJPF {
+public class BufferTest extends TestJPF {
 
-	/**
-	 * This test case checks to see if the missing
-	 * class java.nio.Buffer.<init>(IIII)V issue
-	 * is resolved and fails otherwise
-	 */
-	@Test
-	public void testBufferConstructor() {
-		if (verifyNoPropertyViolation()) {
-			Random random = new Random();
-			byte[] bytes = new byte[8];
-			random.nextBytes(bytes);
-			new Scanner(new String(bytes));
-		}
-	}
+  /**
+   * This test case checks to see if the missing
+   * class java.nio.Buffer.<init>(IIII)V issue
+   * is resolved and fails otherwise
+   */
+  @Test
+  public void testByteBufferConstructor() {
+    if (verifyNoPropertyViolation()) {
+      byte[] bytes1 = "Buffer".getBytes(StandardCharsets.UTF_8);
+      byte[] bytes2 = "testBuffer".getBytes(StandardCharsets.UTF_8);
+
+      ByteBuffer buffer1 = ByteBuffer.wrap(bytes1);
+      ByteBuffer buffer2 = ByteBuffer.wrap(bytes2);
+      buffer2.position(4);
+
+      assertTrue(buffer1.equals(buffer2));
+    }
+  }
+
+  @Test
+  public void testCharBufferConstructor() {
+    if(verifyNoPropertyViolation()) {
+      Random random = new Random();
+      byte[] bytes = new byte[8];
+      random.nextBytes(bytes);
+      new Scanner(new String(bytes));
+    }
+  }
 
 }

--- a/src/tests/gov/nasa/jpf/test/java/nio/ByteBufferTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/nio/ByteBufferTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.java.nio;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.Scanner;
+
+public class ByteBufferTest extends TestJPF {
+
+	/**
+	 * This test case checks to see if the missing
+	 * class java.nio.Buffer.<init>(IIII)V issue
+	 * is resolved and fails otherwise
+	 */
+	@Test
+	public void testBufferConstructor() {
+		if (verifyNoPropertyViolation()) {
+			Random random = new Random();
+			byte[] bytes = new byte[8];
+			random.nextBytes(bytes);
+			new Scanner(new String(bytes));
+		}
+	}
+
+}

--- a/src/tests/gov/nasa/jpf/test/java/text/DecimalFormatTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/text/DecimalFormatTest.java
@@ -26,6 +26,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.FieldPosition;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -63,6 +64,8 @@ public class DecimalFormatTest extends TestJPF {
       NumberFormat format = NumberFormat.getIntegerInstance();
       assertTrue(format.isParseIntegerOnly());
       format = NumberFormat.getNumberInstance();
+      assertFalse(format.isParseIntegerOnly());
+      format = NumberFormat.getNumberInstance(Locale.ENGLISH);
       assertFalse(format.isParseIntegerOnly());
     }
   }


### PR DESCRIPTION
The patch #171 adds a new test `ByteBufferTest` which fails from a different stack trace than the time the issue was first observed. Therefore the incremental fix as part of #244 does not apply.

The `ByteBufferTest`'s `testBufferConstructor()` currently fails with the stack trace below:

`====================================================== error 1
gov.nasa.jpf.vm.NoUncaughtExceptionsProperty
java.lang.NoSuchFieldError: java.nio.HeapCharBuffer.UNSAFE
	at java.nio.HeapCharBuffer.<clinit>(HeapCharBuffer.java:45)
	at java.nio.CharBuffer.allocate(CharBuffer.java:348)
	at java.util.Scanner.<init>(Scanner.java:538)
	at java.util.Scanner.<init>(Scanner.java:766)
	at gov.nasa.jpf.test.java.nio.ByteBufferTest.testBufferConstructor(ByteBufferTest.java:40)
	at java.lang.reflect.Method.invoke(gov.nasa.jpf.vm.JPF_java_lang_reflect_Method)
	at gov.nasa.jpf.util.test.TestJPF.runTestMethod(TestJPF.java:648)`
	
Trying to figure out what causes the test to fail. Thanks!