### PR TITLE
Adds recursive lookup for ClassLoader.defineClass() and unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,17 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'org.ow2.asm:asm:9.5'
     testImplementation('junit:junit:4.13.1')
+}
+
+configurations {
+    customTestImpl.extendsFrom testImplementation
+}
+
+tasks.register('copyLibs', Copy) {
+    from configurations.customTestImpl
+    into 'build'
 }
 
 jar {
@@ -44,27 +54,36 @@ apply from: "gradle/distribution.gradle"
 apply from: "gradle/source-sets.gradle"
 apply from: "gradle/build-resources.gradle"
 
+compileJava.dependsOn(copyLibs)
+
 tasks.named('compileClassesJava') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 tasks.named('compileExamplesJava') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 tasks.named('compileModulesJava') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 tasks.named('compilePeersJava') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 tasks.named('compileTestJava') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 tasks.named('jar') {
+    dependsOn(copyLibs)
     dependsOn(copyResources)
 }
 
 
 tasks.register('compileModules', JavaCompile) {
+    dependsOn(copyLibs)
     dependsOn compileTestJava
     source = fileTree(dir: 'src/classes/modules')
     classpath = files('build/annotations', 'build/classes', 'build/main')
@@ -86,6 +105,7 @@ tasks.register('compile') {
     // These are automatic generated tasks from the Java Gradle Plugin.
     // Gradle is able to infer the order of the source sets
     // due to the compileClasspath attribute
+    dependsOn(copyLibs)
     dependsOn compileExamplesJava
     dependsOn compileModules
 }
@@ -97,6 +117,7 @@ tasks.register('createJpfClassesJar', Jar) {
     group = "JPF Jars"
     description = "Creates the ${archiveFileName} file."
 
+    dependsOn(copyLibs)
     dependsOn compile
     dependsOn copyResources
 
@@ -119,6 +140,7 @@ tasks.register('createJpfJar', Jar) {
     group = "JPF Jars"
     description = "Creates the ${archiveFileName} file."
 
+    dependsOn(copyLibs)
     dependsOn compile
     dependsOn copyResources
 
@@ -142,6 +164,7 @@ tasks.register('createAnnotationsJar', Jar) {
     group = "JPF Jars"
     description = "Creates the ${archiveFileName} file."
 
+    dependsOn(copyLibs)
     dependsOn compile
     dependsOn copyResources
 
@@ -155,6 +178,7 @@ tasks.register('createClassloaderSpecificTestsJar', Jar) {
     group = "JPF Jars"
     description = "Creates the ${archiveFileName} file."
 
+    dependsOn(copyLibs)
     dependsOn compile
     dependsOn copyResources
 
@@ -236,6 +260,7 @@ tasks.register('buildJars') {
     group = "JPF Build"
     description = "Generates all core JPF jar files."
 
+    dependsOn(copyLibs)
     dependsOn createClassloaderSpecificTestsJar
     dependsOn createAnnotationsJar
     dependsOn createJpfClassesJar
@@ -302,7 +327,7 @@ publishing {
         }
     }
 }
-    
+
 def PolDetJPFClasspath = "${buildDir}/tests:" + configurations.testRuntimeClasspath.findAll { it.name.endsWith('jar') && (it.name.contains('junit') || it.name.contains('hamcrest')) }.join(":")
 
 tasks.register('testPolDet', Exec) {

--- a/jpf.properties
+++ b/jpf.properties
@@ -29,6 +29,7 @@ jpf-core.sourcepath=\
   ${jpf-core}/src/examples
 
 jpf-core.test_classpath=\
+  ${jpf-core}/build/asm-9.5.jar;\
   ${jpf-core}/build/tests
 
 jpf-core.peer_packages = gov.nasa.jpf.vm,<model>,<default>

--- a/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/INSTANCEOF.java
@@ -30,25 +30,25 @@ import gov.nasa.jpf.vm.Types;
  * ..., objectref => ..., result
  */
 public class INSTANCEOF extends Instruction implements JVMInstruction {
-  private String type;
+  private String typeSignature;
 
 
   /**
    * typeName is of a/b/C notation
    */
   public INSTANCEOF (String typeName){
-    type = Types.getTypeSignature(typeName, false);
+    typeSignature = Types.getTypeSignature(typeName, false);
   }
 
   @Override
   public Instruction execute (ThreadInfo ti) {
-    if(Types.isReferenceSignature(type)) {
+    if(Types.isReferenceSignature(typeSignature)) {
       String t;
-      if(Types.isArray(type)) {
+      if(Types.isArray(typeSignature)) {
         // retrieve the component terminal
-        t = Types.getComponentTerminal(type);
+        t = Types.getComponentTerminal(typeSignature);
       } else {
-        t = type;
+        t = typeSignature;
       }
 
       // resolve the referenced class
@@ -64,7 +64,7 @@ public class INSTANCEOF extends Instruction implements JVMInstruction {
 
     if (objref == MJIEnv.NULL) {
       frame.push(0);
-    } else if (ti.getElementInfo(objref).instanceOf(type)) {
+    } else if (ti.getElementInfo(objref).instanceOf(typeSignature)) {
       frame.push(1);
     } else {
       frame.push(0);
@@ -74,7 +74,7 @@ public class INSTANCEOF extends Instruction implements JVMInstruction {
   }
   
   public String getType() {
-	  return type;
+	  return typeSignature;
   }
 
   @Override

--- a/src/main/gov/nasa/jpf/vm/ClassInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ClassInfo.java
@@ -1862,6 +1862,11 @@ public class ClassInfo extends InfoObject implements Iterable<MethodInfo>, Gener
 
   public static boolean isBuiltinClass (String cname) {
     char c = cname.charAt(0);
+    
+    // The following handles invalid names, e.g., [Ljava.lang.Object;BeanInfo in Groovy
+    if (cname.indexOf(';') != -1 && cname.indexOf(';') != cname.length() - 1) {
+      return false;
+    }
 
     // array class
     if ((c == '[') || cname.endsWith("[]")) {

--- a/src/main/gov/nasa/jpf/vm/ElementInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ElementInfo.java
@@ -1684,8 +1684,8 @@ public abstract class ElementInfo implements Cloneable {
     
   }
 
-  public boolean instanceOf(String type) {
-    return Types.instanceOf(ci.getType(), type);
+  public boolean instanceOf(String typeSignature) {
+    return Types.instanceOf(ci, typeSignature);
   }
 
   abstract public int getNumberOfFields();

--- a/src/main/gov/nasa/jpf/vm/Types.java
+++ b/src/main/gov/nasa/jpf/vm/Types.java
@@ -1070,30 +1070,18 @@ public class Types {
     return (int) (l >> 32);
   }
 
-  public static boolean instanceOf (String type, String ofType) {
-    int bType = getBuiltinTypeFromSignature(type);
-
-    if ((bType == T_ARRAY) && ofType.equals("Ljava.lang.Object;")) {
-      return true;
+  public static boolean instanceOf (ClassInfo ci, String ofTypeSignature) {
+    int bOfType = getBuiltinTypeFromSignature(ofTypeSignature);
+    if (ci.isArray() && bOfType == T_ARRAY) {
+      return instanceOf(ci.getComponentClassInfo(), getArrayElementType(ofTypeSignature));
     }
 
-    int bOfType = getBuiltinTypeFromSignature(ofType);
-
-    if (bType != bOfType) {
-      return false;
+    if (ci.isPrimitive()) {
+      int bType = getBuiltinTypeFromSignature(ci.getSignature());
+      return bType == bOfType;
     }
 
-    switch (bType) {
-    case T_ARRAY:
-      return instanceOf(type.substring(1), ofType.substring(1));
-
-    case T_REFERENCE:
-      ClassInfo ci = ClassLoaderInfo.getCurrentResolvedClassInfo(getTypeName(type));
-      return ci.isInstanceOf(getTypeName(ofType));
-
-    default:
-      return true;
-    }
+    return ci.isInstanceOf(getTypeName(ofTypeSignature));
   }
 
   public static boolean intToBoolean (int i) {

--- a/src/main/gov/nasa/jpf/vm/Types.java
+++ b/src/main/gov/nasa/jpf/vm/Types.java
@@ -761,7 +761,7 @@ public class Types {
       return typeName;
     }
     
-    int i=typeName.indexOf('[');
+    int i=typeName.indexOf("[]");
     if (i>0){ // the sort of "<type>[]"
       StringBuilder sb = new StringBuilder();
       sb.append('[');

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -112,7 +112,16 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
       Class<?> clazz = Class.forName("x.y.NonExisting");
     }
   }
+  
+  @Test 
+  public void testClassForNameExceptionForInvalidArrayType () throws ClassNotFoundException {
+    if (verifyUnhandledException("java.lang.ClassNotFoundException")) {
 
+      // Adapted from the Groovy library
+      // This tests how array types are handled properly in Types.java (issue #204)
+      Class<?> clazz = Class.forName("groovy.runtime.metaclass.[Ljava.lang.Object;MetaClass");
+    }
+  }
   
   static class X {
     static {


### PR DESCRIPTION
Hello @cyrille-artho and @pparizek,

This PR combines a set of related patches which add functionality and fix bugs. The patches involved here are #203, #208, #209 and #388, which means #410 can now be skipped as it is same as #388 minus the unit test in `ClassLoaderTest`.

The patch adds a total of 6 unit tests. All 1002 tests now pass.

Some refactors were necessary in the `build.gradle` file to comply the added dependency for **asm** and the task with the latest gradle version.

Thanks!