### PR TITLE
Disable the jacoco task from executing by default. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,7 @@ test {
     description = "Runs core regression tests."
 
     dependsOn buildJars
+    jacoco.enabled = false
 
     forkEvery = 1
     enableAssertions = true

--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,6 @@ test {
     description = "Runs core regression tests."
 
     dependsOn buildJars
-    finalizedBy jacocoTestReport
 
     forkEvery = 1
     enableAssertions = true
@@ -309,7 +308,6 @@ jacoco {
 }
 
 jacocoTestReport {
-    dependsOn test
     reports {
         xml.required = false
         csv.required = false


### PR DESCRIPTION
Retain jacocoTestReport as a standalone task which can be run by executing the command `./gradlew jacocoTestReport`