### PR TITLE
Terminate the thread when unhandled exception happens.

### DIFF
--- a/src/main/gov/nasa/jpf/vm/ThreadInfo.java
+++ b/src/main/gov/nasa/jpf/vm/ThreadInfo.java
@@ -2881,14 +2881,10 @@ public class ThreadInfo extends InfoObject
 
       // there was no overridden uncaughtHandler, or we already executed it
       if ("java.lang.ThreadDeath".equals(exceptionName)) { // gracefully shut down
-        unwindToFirstFrame();
         pendingException = null;
-        return top.getPC().getNext(); // the final DIRECTCALLRETURN
-
-      } else { // we have a NoUncaughtPropertyViolation
-        //NoUncaughtExceptionsProperty.setExceptionInfo(pendingException);
-        throw new UncaughtException(this, exceptionObjRef);
       }
+      unwindToFirstFrame();
+      return top.getPC().getNext(); // the final DIRECTCALLRETURN
 
     } else { // we found a matching handler
       

--- a/src/tests/gov/nasa/jpf/test/java/concurrent/ThreadExceptionTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/concurrent/ThreadExceptionTest.java
@@ -1,0 +1,18 @@
+package gov.nasa.jpf.test.java.concurrent;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+
+public class ThreadExceptionTest extends TestJPF {
+    @Test
+    public void testResourceAcquisition() {
+        if (verifyUnhandledException("java.lang.RuntimeException",
+                "+search.class=gov.nasa.jpf.search.RandomSearch",
+                "+cg.randomize_choices=FIXED_SEED", "+search.RandomSearch.path_limit=10", "+search.multiple_errors=true")) {
+            Thread t = new Thread(() -> {
+                throw new RuntimeException("Exception from thread");
+            });
+            t.start();
+        }
+    }
+}


### PR DESCRIPTION
JPF is failing the added test `ThreadExceptionTest` because it does not terminate a thread when an unhandled exception occurs. This PR fixed this issue by continuing to execute the `DIRECTCALLRETURN` instruction instead of throwing the UncaughtException. 