### PR TITLE
Fix container inefficiency in HeuristicSearch.java

### DIFF
--- a/src/main/gov/nasa/jpf/search/heuristic/HeuristicSearch.java
+++ b/src/main/gov/nasa/jpf/search/heuristic/HeuristicSearch.java
@@ -55,12 +55,18 @@ public abstract class HeuristicSearch extends Search {
    */
   protected boolean isBeamSearch;
 
+  /*
+   * allocate childStates on needed (useChildStates == true)
+   */
+  protected boolean useChildStates;
+
   
   public HeuristicSearch (Config config, VM vm) {
     super(config, vm);
     
     useAstar = config.getBoolean("search.heuristic.astar");
     isBeamSearch = config.getBoolean("search.heuristic.beam_search");
+    useChildStates = config.getBoolean("search.heuristic.child_states");
   }
 
   
@@ -104,8 +110,9 @@ public abstract class HeuristicSearch extends Search {
    * explicit termination request
    */
   protected boolean generateChildren () {
-
-    childStates = new ArrayList<HeuristicState>();
+    if (useChildStates) {
+      childStates = new ArrayList<HeuristicState>();
+    }
     
     while (!done) {
       
@@ -146,7 +153,9 @@ public abstract class HeuristicSearch extends Search {
           
             HeuristicState newHState = queueCurrentState();            
             if (newHState != null) { 
-              childStates.add(newHState);
+              if (useChildStates) {
+                childStates.add(newHState);
+              }
               notifyStateStored();
             }
           }


### PR DESCRIPTION
Hi,

We find that there exist container inefficiency in HeuristicSearch.java.

The method `getChildStates` is never invoked in current repo. 
And the List object `childStates` has no use in all the subclasses in current repo.
Therefore, the objects in List object `childStates` is are never accessed.
We add an attribute `useChildStates` to control the allocation of `childStates` when needed.

We discovered the above container inefficiency using our tool cinst. The patch is submitted.
Could you please check and accept it? We have tested the patch on our PC. The patched program works well.