### PR TITLE
Fixed the error when Empty main runs with VerTracker

### DIFF
--- a/src/main/gov/nasa/jpf/listener/VarTracker.java
+++ b/src/main/gov/nasa/jpf/listener/VarTracker.java
@@ -191,7 +191,9 @@ public class VarTracker extends ListenerAdapter {
       varId = ((JVMFieldInstruction)executedInsn).getFieldName();
 
       StackFrame frame = ti.getModifiableTopFrame();
-      frame.addOperandAttr(varId);
+      if (frame.getTopPos() >= 0) {
+        frame.addOperandAttr(varId);
+      }
 
 
     // here come the changes - note that we can't update the stats right away,

--- a/src/tests/gov/nasa/jpf/listener/VerTrackerTest.java
+++ b/src/tests/gov/nasa/jpf/listener/VerTrackerTest.java
@@ -1,0 +1,21 @@
+package gov.nasa.jpf.listener;
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+
+class Emptymain{
+    public static void main(String[] args) {
+
+    }
+}
+public class VerTrackerTest extends TestJPF {
+    @Test
+      public void test_Emptymain(){
+        if(verifyNoPropertyViolation("+listener=gov.nasa.jpf.listener.VarTracker")){
+          Emptymain.main(null);
+        }
+    }
+    public static void main(String[] args) {
+        runTestsOfThisClass(null);
+    }
+
+}


### PR DESCRIPTION
### Description  : 

  This PR fixes the error when we run an empty main set to a VerTracker listener. 

### Issue Fixed :
  
  #380

### Testing :
  
    I added a test that calls the empty main method setting the listener to VerTracker.

###Fix :

  -  The error was reflected because the addOperandAttr() method was called in the VerTracker without checking if the 
       operand stack was empty.

  -  The if condition `(frame.getTopPos() >= 0)` checks for the above undetected condition.
 
