### PR TITLE
VM.getSavedProperty("os.name") not supported 

### DIFF
--- a/src/classes/modules/java.base/java/lang/System.java
+++ b/src/classes/modules/java.base/java/lang/System.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 import jdk.internal.misc.JavaLangAccess;
 import jdk.internal.misc.SharedSecrets;
+import jdk.internal.misc.VM;
 import jdk.internal.reflect.ConstantPool;
 import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
@@ -70,6 +71,9 @@ public class System {
     // <2do> this is an approximation that isn't particularly safe since we don't
     // initialize sun.misc.VM
     //sun.misc.VM.booted();
+ 
+    //Loading all Properties to VM
+    VM.saveAndRemoveProperties(properties);
   }
 
   static JavaLangAccess createJavaLangAccess () {

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_System.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_System.java
@@ -184,6 +184,7 @@ public class JPF_java_lang_System extends NativePeer {
         "java.home",
         "java.version",
         "java.io.tmpdir",
+	"os.name",
         JAVA_CLASS_PATH
         //... and probably some more
         // <2do> what about -Dkey=value commandline options

--- a/src/tests/gov/nasa/jpf/test/java/misc/VMTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/misc/VMTest.java
@@ -1,0 +1,31 @@
+package gov.nasa.jpf.test.java.misc;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import jdk.internal.misc.VM;
+import org.junit.Test;
+
+/**
+ * Simple test to verify properties are loaded correctly to VM
+ */
+public class VMTest extends TestJPF {
+
+  /**
+   * Test to verify all the properties of System is loaded to VM
+   */
+  @Test
+  public void getSavedPropertiesTest(){
+    if(verifyNoPropertyViolation()){
+      assertEquals(System.getProperties().size(),VM.getSavedProperties().size());
+    }
+  }
+
+  /**
+   * Test to verify property "os.name" is loaded in VM
+   */
+  @Test
+  public void getSavedPropertyTest(){
+    if(verifyNoPropertyViolation()){
+      assertNotNull(VM.getSavedProperty("os.name"));
+    }
+  }
+}


### PR DESCRIPTION
### Description
This PR adds `os.name` key into native peer for `java.lang.System` to fethc OS name from Host VM. Also adds test case to test `VM.getSavedProperty` functionality in JPF.

### Related issue(s)
Fixes #495 