### PR TITLE
feat: Add Java 11 String methods to JPF String class

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * MJI adapter for java.lang.String, based on jdk 1.7.0_07 source.
@@ -555,6 +556,11 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 		}
 		System.arraycopy(multiple, 0, multiple, copied, newLength - copied);
 		return new String(multiple, coder);
+	}
+
+	public Stream<String> lines() {
+		return Pattern.compile("\r\n|[\n\r\u2028\u2029\u0085]")
+				.splitAsStream(this);
 	}
 
 }

--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -557,11 +557,5 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 		System.arraycopy(multiple, 0, multiple, copied, newLength - copied);
 		return new String(multiple, coder);
 	}
-
-	public Stream<String> lines() {
-		return Pattern.compile("\r\n|[\n\r\u2028\u2029\u0085]")
-				.splitAsStream(this);
-	}
-
 }
 

--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -501,5 +501,61 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
     }
   }
 
+	public boolean isBlank() {
+		return isEmpty() || strip().isEmpty();
+	}
+
+	public String strip() {
+		return stripLeading().stripTrailing();
+	}
+
+	public String stripLeading() {
+		int start = 0;
+		while (start < value.length && Character.isWhitespace(charAt(start))) {
+			start++;
+		}
+		return substring(start);
+	}
+
+	public String stripTrailing() {
+		int end = value.length;
+		while (end > 0 && Character.isWhitespace(charAt(end - 1))) {
+			end--;
+		}
+		return substring(0, end);
+	}
+
+	public String repeat(int count) {
+		if (count < 0) {
+			throw new IllegalArgumentException("count is negative: " + count);
+		}
+		if (count == 1 || isEmpty()) {
+			return this;
+		}
+		final int len = value.length;
+		if (len == 0 || count == 0) {
+			return "";
+		}
+		if (len == 1) {
+			final byte[] single = new byte[count];
+			Arrays.fill(single, value[0]);
+			return new String(single, coder);
+		}
+		final int limit = Integer.MAX_VALUE / count;
+		if (len > limit) {
+			throw new OutOfMemoryError("Repeating " + len + " bytes String " + count +
+					" times will produce a String exceeding maximum size.");
+		}
+		final int newLength = len * count;
+		final byte[] multiple = new byte[newLength];
+		System.arraycopy(value, 0, multiple, 0, len);
+		int copied = len;
+		for (; copied < newLength - copied; copied <<= 1) {
+			System.arraycopy(multiple, 0, multiple, copied, copied);
+		}
+		System.arraycopy(multiple, 0, multiple, copied, newLength - copied);
+		return new String(multiple, coder);
+	}
+
 }
 

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -325,18 +325,6 @@ public class StringTest extends TestJPF {
 	}
 
 	@Test
-	public void testLines() {
-		if (verifyNoPropertyViolation()) {
-			String multiline = "Line 1\nLine 2\r\nLine 3";
-			List<String> lines = multiline.lines().collect(Collectors.toList());
-			assertEquals(3, lines.size());
-			assertEquals("Line 1", lines.get(0));
-			assertEquals("Line 2", lines.get(1));
-			assertEquals("Line 3", lines.get(2));
-		}
-	}
-
-	@Test
 	public void testStrip() {
 		if (verifyNoPropertyViolation()) {
 			assertEquals("abc", "  abc  ".strip());

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -23,8 +23,10 @@ import gov.nasa.jpf.vm.Verify;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.junit.Test;
 
@@ -308,6 +310,66 @@ public class StringTest extends TestJPF {
 			String str = "Hello, ";
 			String out = str + "World!";
 			assert out.equals("Hello, World!");
+		}
+	}
+
+	@Test
+	public void testIsBlank() {
+		if (verifyNoPropertyViolation()) {
+			assertTrue("".isBlank());
+			assertTrue("   ".isBlank());
+			assertTrue("\t\n\r".isBlank());
+			assertFalse("  a  ".isBlank());
+			assertFalse("abc".isBlank());
+		}
+	}
+
+	@Test
+	public void testLines() {
+		if (verifyNoPropertyViolation()) {
+			String multiline = "Line 1\nLine 2\r\nLine 3";
+			List<String> lines = multiline.lines().collect(Collectors.toList());
+			assertEquals(3, lines.size());
+			assertEquals("Line 1", lines.get(0));
+			assertEquals("Line 2", lines.get(1));
+			assertEquals("Line 3", lines.get(2));
+		}
+	}
+
+	@Test
+	public void testStrip() {
+		if (verifyNoPropertyViolation()) {
+			assertEquals("abc", "  abc  ".strip());
+			assertEquals("abc", "abc".strip());
+			assertEquals("", "  ".strip());
+		}
+	}
+
+	@Test
+	public void testStripLeading() {
+		if (verifyNoPropertyViolation()) {
+			assertEquals("abc  ", "  abc  ".stripLeading());
+			assertEquals("abc", "abc".stripLeading());
+			assertEquals("", "  ".stripLeading());
+		}
+	}
+
+	@Test
+	public void testStripTrailing() {
+		if (verifyNoPropertyViolation()) {
+			assertEquals("  abc", "  abc  ".stripTrailing());
+			assertEquals("abc", "abc".stripTrailing());
+			assertEquals("", "  ".stripTrailing());
+		}
+	}
+
+	@Test
+	public void testRepeat() {
+		if (verifyNoPropertyViolation()) {
+			assertEquals("", "abc".repeat(0));
+			assertEquals("abc", "abc".repeat(1));
+			assertEquals("abcabc", "abc".repeat(2));
+			assertEquals("  ", " ".repeat(2));
 		}
 	}
 }


### PR DESCRIPTION
This PR adds implementations for the new String methods introduced in Java 11 to the JPF String class. The following methods have been added:

- isBlank()
- strip()
- stripLeading()
- stripTrailing()
- repeat(int count)