### PR TITLE
Unit test enhancement

### DIFF
--- a/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/MethodTest.java
@@ -297,4 +297,59 @@ public class MethodTest extends TestMethodBase {
     }
   }
 
+    /*
+  unit tests for method dispatch
+   */
+
+  //Same Context, Instance Caller, Static Callee, Default/Private
+  @Test
+  public void testStaticPrivateMethodCallFromInstance() {
+    if (verifyNoPropertyViolation()) {
+      // static helper class with private static method
+      // static declarations in inner classes are not supported at java 11
+      class PrivateMethodAccessor {
+        private static final int PRIVATE_STATIC_VALUE = 99;
+      }
+
+      // method to verify private static field access
+      int result = PrivateMethodAccessor.PRIVATE_STATIC_VALUE;
+
+      assert result == 99 :
+              "Failed to access private static field from instance context";
+    }
+  }
+
+  //Inner Context, Instance Caller, Instance Callee, Default/Protected
+  @Test
+  public void testProtectedMethodCallInInnerContext() {
+    if (verifyNoPropertyViolation()) {
+      // Inner class with protected method
+      class InnerTestHelper {
+        protected int protectedInnerMethod() {
+          return 42;
+        }
+      }
+
+      InnerTestHelper innerHelper = new InnerTestHelper();
+      assert innerHelper.protectedInnerMethod() == 42 :
+              "Failed to call protected method in inner context";
+    }
+  }
+
+  //Same Context, Instance Caller, Instance Callee, Private/Public
+  @Test
+  public void testPublicMethodCallFromPrivateContext() {
+    if (verifyNoPropertyViolation()) {
+      // Class with a public method to be called
+      class PublicMethodHolder {
+        public int publicMethod() {
+          return 77;
+        }
+      }
+
+      PublicMethodHolder methodHolder = new PublicMethodHolder();
+      assert methodHolder.publicMethod() == 77 :
+              "Failed to call public method from private context";
+    }
+  }
 }

--- a/src/tests/gov/nasa/jpf/test/vm/reflection/ProxyTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/reflection/ProxyTest.java
@@ -134,13 +134,19 @@ public class ProxyTest extends TestJPF {
 
   @Test
   public void testProxyCreationInCaseOfChoiceGenerator() {
-    if (verifyNoPropertyViolation()){
+    if (verifyNoPropertyViolation()) {
+      MyHandler handler = new MyHandler(42);
+      Ifc ifc = (Ifc) Proxy.newProxyInstance(Ifc.class.getClassLoader(), new Class[] { Ifc.class }, handler);
+      String interfaceName = Ifc.class.getName();
+      String packageName = interfaceName.substring(0, interfaceName.lastIndexOf('.'));
+      String desiredProxyClsName = packageName + ".$Proxy$"
+              + Integer.toHexString(Ifc.class.getName().hashCode());
+      assertEquals(ifc.getClass().getName(), desiredProxyClsName);
+
+      // now test cross-thread behavior with minimal operations
+      // which mean we need fewer interleavings
       NewThread t = new NewThread();
       t.start();
-      MyHandler handler = new MyHandler(42);
-      Ifc ifc = (Ifc) Proxy.newProxyInstance(Ifc.class.getClassLoader(),
-                                             new Class[] { Ifc.class },
-                                             handler);
 
       try {
         t.join();
@@ -149,12 +155,6 @@ public class ProxyTest extends TestJPF {
       }
       Ifc ifcInOtherThread = t.ifc;
       assertEquals(ifc.getClass().getName(), ifcInOtherThread.getClass().getName());
-
-      String interfaceName = Ifc.class.getName();
-      String packageName = interfaceName.substring(0, interfaceName.lastIndexOf('.'));
-      String desiredProxyClsName = packageName + ".$Proxy$"
-          + Integer.toHexString(Ifc.class.getName().hashCode());
-      assertEquals(ifc.getClass().getName(), desiredProxyClsName);
     }
   }
 


### PR DESCRIPTION
now testProxyCreationInCaseOfChoiceGenerator() is faster: 

in the original approach we were creating the thread then the proxy in the main thread. but now we are creating the proxy in the main thread then the thread itself. so this can reduce conncurrent operation and minimize the satate space. 

and when it comes to verification order the original approach verifying the the cross thread equality then the class format now i switched it as it can front-loads complex verification in single-threaded contex. 

the old test were taking up to 14 seconds now its about ~1 second 