### PR TITLE
add missing dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ tasks.named('compilePeersJava') {
 tasks.named('compileTestJava') {
     dependsOn(copyLibs)
     dependsOn(copyResources)
+    dependsOn(compileModulesJava)
 }
 tasks.named('jar') {
     dependsOn(copyLibs)


### PR DESCRIPTION
`compileTestJava` should reply on `compileModulesJava`. The vscode will throw an error when running a single test without this change