### PR TITLE
Fix typo: "rnge" → "range" in comment

### DIFF
--- a/src/examples/NumericValueCheck.java
+++ b/src/examples/NumericValueCheck.java
@@ -17,7 +17,7 @@
  */
 
 /**
- * example to catch numeric value rnge violations with the NumericValueChecker listener
+ * example to catch numeric value range violations with the NumericValueChecker listener
  */
 public class NumericValueCheck {
   


### PR DESCRIPTION
This PR fixes a small typo in the file comment where “rnge” was misspelled.