### PR TITLE
Fix VM.getSavedProperty('os.name') not supported

### DIFF
--- a/gradle/source-sets.gradle
+++ b/gradle/source-sets.gradle
@@ -60,3 +60,6 @@ compileModulesJava.options.compilerArgs += [
 compileTestJava.options.compilerArgs += [
         '--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED'
 ]
+compileExamplesJava.options.compilerArgs += [
+    '--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED'
+]

--- a/src/classes/modules/java.base/java/lang/System.java
+++ b/src/classes/modules/java.base/java/lang/System.java
@@ -28,6 +28,7 @@ import jdk.internal.misc.SharedSecrets;
 import jdk.internal.reflect.ConstantPool;
 import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
+import jdk.internal.misc.VM;
 
 
 public class System {
@@ -66,7 +67,7 @@ public class System {
     // would have prefered not to learn about. It's a mess WRT Java 1.5 / 6 compatibility
     // <2do> - most if this isn't supported yet
     SharedSecrets.setJavaLangAccess( createJavaLangAccess());
-
+    
     // <2do> this is an approximation that isn't particularly safe since we don't
     // initialize sun.misc.VM
     //sun.misc.VM.booted();

--- a/src/classes/modules/java.base/jdk/internal/misc/VM.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/VM.java
@@ -1,0 +1,16 @@
+package jdk.internal.misc;
+
+import java.util.Properties;
+
+public class VM {
+    
+    private static native void initialize();
+    
+    public static native void saveAndRemoveProperties(Properties props);
+    
+    public static native String getSavedProperty(String key);
+    
+    static {
+        initialize();
+    }
+}

--- a/src/examples/VMPropertyTest.java
+++ b/src/examples/VMPropertyTest.java
@@ -1,0 +1,5 @@
+public class VMPropertyTest {
+  public static void main(String[] args) {
+    System.out.println(jdk.internal.misc.VM.getSavedProperty("os.name"));
+  }
+}

--- a/src/examples/VMPropertyTest.jpf
+++ b/src/examples/VMPropertyTest.jpf
@@ -1,0 +1,1 @@
+target=VMPropertyTest

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_System.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_System.java
@@ -181,6 +181,7 @@ public class JPF_java_lang_System extends NativePeer {
         "user.home",
         "user.timezone",
         "user.country",
+        "os.name",
         "java.home",
         "java.version",
         "java.io.tmpdir",


### PR DESCRIPTION
- Add 'os.name' to system properties list in JPF_java_lang_System.java
- Implement jdk.internal.misc.VM class with native methods
- Add VM peer with saved property management in JPF_jdk_internal_misc_VM.java
- Initialize VM saved properties from system properties during VM init
- Add compilation exports for examples in source-sets.gradle
- Include test case VMPropertyTest.java to verify functionality

Resolves GitHub issue #495