### PR TITLE
Add Java 11 Nestmate support to java.lang.Class model

### DIFF
--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -408,4 +408,18 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   public Module getModule() {
     return module;
   }
+  public Class<?> getNestHost() {
+    Class<?> host = this;
+    while (host.getEnclosingClass() != null) {
+      host = host.getEnclosingClass();
+    }
+    return host;
+  }
+
+  public boolean isNestmateOf(Class<?> c) {
+    if (c == null) {
+      return false;
+    }
+    return this.getNestHost() == c.getNestHost();
+  }
 }

--- a/src/tests/gov/nasa/jpf/test/java/lang/NestmateTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/NestmateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gov.nasa.jpf.test.java.lang;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+import static org.junit.Assert.*; // <-- This was the missing magic line!
+
+public class NestmateTest extends TestJPF {
+
+    public class Inner {}
+
+    @Test
+    public void testNestHost() {
+        if (verifyNoPropertyViolation()) {
+            Class<?> host = NestmateTest.class.getNestHost();
+            assertEquals(NestmateTest.class, host);
+            Class<?> innerHost = Inner.class.getNestHost();
+            assertEquals(NestmateTest.class, innerHost);
+        }
+    }
+
+    @Test
+    public void testIsNestmateOf() {
+        if (verifyNoPropertyViolation()) {
+            assertTrue(NestmateTest.class.isNestmateOf(Inner.class));
+            assertTrue(Inner.class.isNestmateOf(NestmateTest.class));
+        }
+    }
+
+    @Test
+    public void testPrimitiveArrayVoidNestHost() {
+        if (verifyNoPropertyViolation()) {
+            // Primitive
+            assertEquals(int.class, int.class.getNestHost());
+            assertEquals(double.class, double.class.getNestHost());
+
+            // Array
+            assertEquals(int[].class, int[].class.getNestHost());
+            assertEquals(String[].class, String[].class.getNestHost());
+
+            // Void
+            assertEquals(void.class, void.class.getNestHost());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implemented missing Java 11 Nestmate access control methods in the `java.lang.Class` model. This allows JPF to execute code that relies on `getNestHost()` and `isNestmateOf()`, which are increasingly common in modern Java libraries.

## Changes
- **Modified:** `src/classes/modules/java.base/java/lang/Class.java`
  - Added `getNestHost()`: Traversing `getEnclosingClass()` to find the nest host (top-level class).
  - Added `isNestmateOf(Class)`: Compares nest hosts of two classes.
- **Added:** `src/tests/gov/nasa/jpf/test/java/lang/NestmateTest.java`
  - Verified behavior for Top-Level classes (host is self).
  - Verified behavior for Inner classes (host is enclosing class).

## Testing
- `NestmateTest.java` passes 
- Full build successful.

## Relation to Issues
Partial fix for general "Missing Methods in Class" issues (like #235), specifically targeting Java 11 support.