### PR TITLE
Use ZonedDateTime instead of LocalTime to handle midnight wrapping

### DIFF
--- a/src/tests/gov/nasa/jpf/test/java/util/java.timeTest/ClockTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/util/java.timeTest/ClockTest.java
@@ -56,8 +56,8 @@ public class ClockTest extends TestJPF {
     Clock eastCoastStandardTime = Clock.system(withZoneId.apply("EST"));
     Clock eastCoastDaylightSavingsTime = Clock.offset(eastCoastStandardTime, Duration.of(1,ChronoUnit.HOURS));
 
-    LocalTime est = LocalTime.now(eastCoastStandardTime);
-    LocalTime edt = LocalTime.now(eastCoastDaylightSavingsTime);
+    ZonedDateTime est = ZonedDateTime.now(eastCoastStandardTime);
+    ZonedDateTime edt = ZonedDateTime.now(eastCoastDaylightSavingsTime);
 
     long timeDifference = edt.until(est,ChronoUnit.HOURS);
     assertThat(timeDifference,is(-1L));


### PR DESCRIPTION
### Description
This PR fixes a flaky unit test (`change_clock_duration_test`) that fails consistently during the one hour before midnight.

### The Bug
The test previously used `LocalTime` to calculate the difference between two clocks. 
* **Scenario:** When the time is `23:00` (11 PM).
* **Logic:** `est` is `23:00`. The offset clock `edt` is `23:00` + 1 hour = `00:00`.
* **Failure:** `LocalTime` discards date information. It calculates the difference between `23:00` and `00:00` (on the same abstract day) as `+23 hours` instead of `-1 hour`. This caused the assertion `assertThat(timeDifference, is(-1L))` to fail.

### The Fix
Replaced `LocalTime` with `ZonedDateTime`. 
`ZonedDateTime` preserves the date information, so when the time wraps past midnight to the next day, the `until()` calculation correctly identifies the time difference as `-1 hour`.

### Verification
* Verified locally by mocking `Clock.fixed()` at `23:00` to reproduce the failure.
* Confirmed that `ZonedDateTime` resolves the assertion correctly at the midnight boundary.