### PR TITLE
Add initial scaffolding for Java 17 classfiles

### DIFF
--- a/src/classes/modules/java.base/java/lang/Record.java
+++ b/src/classes/modules/java.base/java/lang/Record.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package java.base.java.lang;
+
+/**
+ * MJI model class for java.lang.Record.
+ * All Java Records implicitly extend this class.
+ */
+public abstract class Record {
+    protected Record() {}
+
+    @Override
+    public abstract boolean equals(Object obj);
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract String toString();
+}

--- a/src/main/gov/nasa/jpf/jvm/ClassFile.java
+++ b/src/main/gov/nasa/jpf/jvm/ClassFile.java
@@ -46,7 +46,7 @@ public class ClassFile extends BinaryClassSource {
   public static final int METHOD_HANDLE = 15;
   public static final int METHOD_TYPE = 16;
   public static final int INVOKE_DYNAMIC = 18;
-  private static final int MAX_SUPPORTED_VERSION = 55;
+  private static final int MAX_SUPPORTED_VERSION = 61;
 
   public static final int REF_GETFIELD = 1;
   public static final int REF_GETSTATIC = 2;
@@ -217,11 +217,13 @@ public class ClassFile extends BinaryClassSource {
   public static final String  INNER_CLASSES_ATTR = "InnerClasses";
   public static final String  ENCLOSING_METHOD_ATTR = "EnclosingMethod";
   public static final String  BOOTSTRAP_METHOD_ATTR = "BootstrapMethods";
+  public static final String RECORD_ATTR = "Record";
+  public static final String PERMITTED_SUBCLASSES_ATTR = "PermittedSubclasses";
   
   protected final static String[] stdClassAttrs = {
     SOURCE_FILE_ATTR, DEPRECATED_ATTR, INNER_CLASSES_ATTR, DEPRECATED_ATTR, SIGNATURE_ATTR,
     RUNTIME_INVISIBLE_ANNOTATIONS_ATTR, RUNTIME_VISIBLE_ANNOTATIONS_ATTR, RUNTIME_VISIBLE_TYPE_ANNOTATIONS_ATTR,
-    ENCLOSING_METHOD_ATTR, BOOTSTRAP_METHOD_ATTR };
+    ENCLOSING_METHOD_ATTR, BOOTSTRAP_METHOD_ATTR, RECORD_ATTR, PERMITTED_SUBCLASSES_ATTR };
 
 
   protected String internStdAttrName(int cpIdx, String name, String[] stdNames){

--- a/src/tests/gov/nasa/jpf/jvm/FileVersionTest.java
+++ b/src/tests/gov/nasa/jpf/jvm/FileVersionTest.java
@@ -39,8 +39,8 @@ public class FileVersionTest extends TestJPF {
         classFile.parse(reader);
     }
 
-    @Test(expected = ClassParseException.class)
-    public void testUnsupportedVersionJava17() throws IOException, ClassParseException {
+    @Test
+    public void testSupportedVersionJava17() throws IOException, ClassParseException {
         byte[] classData = loadClassFile(JAVA17_CLASS);
         ClassFile classFile = new ClassFile(classData);
         ClassFileReader reader = new ClassFileReaderAdapter();


### PR DESCRIPTION
**Fixes #599 **

### Description
This draft PR implements the initial scaffolding outlined in the linked issue to unblock JPF from reading Java 17 binaries. 

### Changes Made
* **`ClassFile.java`**: Bumped `MAX_SUPPORTED_VERSION` to `61` and registered `Record` and `PermittedSubclasses` attributes.
* **`java.lang.Record.java`**: Added a base MJI model stub so the engine does not crash during class resolution when encountering a Java Record.
* **`FileVersionTest.java`**: Updated `testUnsupportedVersionJava17` to `testSupportedVersionJava17`, verifying that the engine now successfully accepts the version 61 classfile.

### Testing
Ran `./gradlew test` and all tests pass, including the newly updated `FileVersionTest`. 