### PR TITLE
Fix: fields shadowing with sealed classes.

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -43,8 +43,6 @@ public class JVMClassInfo extends ClassInfo {
   // To store partially resolved classes in setBootstrapMethod
   protected static HashMap resolvedClasses = new HashMap<String, JVMClassInfo>();
   protected ClassFile classFile;
-  protected String[] permittedSubclassNames;
-  protected boolean isSealed;
 
   class Initializer extends ClassFileReaderAdapter {
     protected ClassFile cf;


### PR DESCRIPTION
In issue #605, the `JVMClassInfo ` has a shadowing fields: `permittedSubclassNames`, `isSealed`, that are exist in parent class `ClassInfo`. Removing this redefined field solves the problem.