### PR TITLE
feat: Add Java 11 String.lines() method with tests

### DIFF
--- a/src/classes/modules/java.base/java/lang/String.java
+++ b/src/classes/modules/java.base/java/lang/String.java
@@ -556,5 +556,30 @@ implements java.io.Serializable, Comparable<String>, CharSequence {
 		System.arraycopy(multiple, 0, multiple, copied, newLength - copied);
 		return new String(multiple, coder);
 	}
+
+	public java.util.stream.Stream<String> lines() {
+	int len = length();
+	java.util.ArrayList<String> result = new java.util.ArrayList<>();
+
+	int start = 0;
+
+	for (int i = 0; i < len; i++) {
+		char c = charAt(i);
+		if (c == '\n' || c == '\r') {
+		result.add(substring(start, i));
+		  if (c == '\r' && i + 1 < len && charAt(i + 1) == '\n') {
+				i++;
+		  }
+
+		  start = i + 1;
+		}
+	}
+
+	if (start < len) {
+		result.add(substring(start, len));
+	}
+
+	return result.stream();
+	}
 }
 

--- a/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/StringTest.java
@@ -360,4 +360,45 @@ public class StringTest extends TestJPF {
 			assertEquals("  ", " ".repeat(2));
 		}
 	}
+
+	@Test
+	public void testLines() {
+		if (verifyNoPropertyViolation()) {
+			String s = "a\nb\nc";
+
+			java.util.List<String> lines =
+				s.lines().collect(java.util.stream.Collectors.toList());
+
+			assertEquals(3, lines.size());
+			assertEquals("a", lines.get(0));
+			assertEquals("b", lines.get(1));
+			assertEquals("c", lines.get(2));
+		}
+	}
+
+	@Test
+	public void testLinesTrailingNewline() {
+		if (verifyNoPropertyViolation()) {
+			String s = "a\nb\n";
+
+			java.util.List<String> lines =
+				s.lines().collect(java.util.stream.Collectors.toList());
+
+			assertEquals(2, lines.size());
+			assertEquals("a", lines.get(0));
+			assertEquals("b", lines.get(1));
+		}
+	}
+
+	@Test
+	public void testLinesEmpty() {
+		if (verifyNoPropertyViolation()) {
+			String s = "";
+
+			java.util.List<String> lines =
+				s.lines().collect(java.util.stream.Collectors.toList());
+
+			assertEquals(0, lines.size());
+		}
+	}
 }


### PR DESCRIPTION
This PR adds support for the Java 11 String method `lines()` in JPF

As recommended by @cyrille-artho in the thread conversation of issue  #313 

The tests were added first to see that the unit tests fail, implementation ensured the unit test is fixed, following the recommended workflow

This PR:
-implements lines() in String.java which returns `Stream<String>`
-handles line terminators: \n, \r, and \r\n
-adds unit tests, normal and edge cases( trailing newline and empty string)

Fixes  #313 