### PR TITLE
Add minimal support for dynamic invokedynamic bootstrap methods

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -195,9 +195,10 @@ public class JVMClassInfo extends ClassInfo {
     }
     private void objectMethodsBootstrap(ClassFile cf, Object tag, int idx, int refKind, String cls, String mth,
                                         String parameters, String descriptor, int[] cpArgs) {
-        handleDynamicBootstrapMethod(cf, tag, idx, refKind, cls, mth, parameters, descriptor, cpArgs);
-        // we are here using proper descriptor instead of sam
-        bootstrapMethods[idx].setRecordComponents(cf.getBmArgString(cpArgs[1]));
+        String components = cf.getBmArgString(cpArgs[1]);
+        bootstrapMethods[idx] = new BootstrapMethodInfo(refKind, JVMClassInfo.this, null, descriptor, components,
+                BootstrapMethodInfo.BMType.RECORDS);
+        bootstrapMethods[idx].setRecordComponents(components);
     }
 
     private void stringConcatenation(ClassFile cf, int idx, int refKind, String cls, String mth, String parameters, String descriptor, int[] cpArgs){

--- a/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
@@ -35,6 +35,8 @@ import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 
 /**
@@ -286,9 +288,173 @@ public class INVOKEDYNAMIC extends Instruction {
     return ti.getHeap().newString(sb.toString(), ti).getObjectRef();
   }
 
+  private static String normalizeClassName(String className) {
+    return className.replace('/', '.');
+  }
+
+  private static ClassLoader getHostClassLoader() {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = INVOKEDYNAMIC.class.getClassLoader();
+    }
+    return cl;
+  }
+
+  private static Class<?>[] getParameterTypes(MethodType type) {
+    Class<?>[] parameterTypes = new Class<?>[type.parameterCount()];
+    for (int i = 0; i < parameterTypes.length; i++) {
+      parameterTypes[i] = type.parameterType(i);
+    }
+    return parameterTypes;
+  }
+
+  private static Method findBootstrapMethod(Class<?> bootstrapClass, BootstrapMethodInfo bmi)
+      throws NoSuchMethodException {
+    MethodType bootstrapType = MethodType.fromMethodDescriptorString(bmi.getDynamicParameters(), getHostClassLoader());
+    Method method = bootstrapClass.getDeclaredMethod(bmi.getDynamicMethodName(), getParameterTypes(bootstrapType));
+
+    if (!Modifier.isStatic(method.getModifiers())) {
+      throw new NoSuchMethodException("bootstrap method is not static: " + method);
+    }
+
+    method.setAccessible(true);
+    return method;
+  }
+
+  private Object[] getBootstrapArguments(BootstrapMethodInfo bmi, MethodType callSiteType) {
+    Object[] resolvedArgs = bmi.getResolvedArgs();
+    Object[] args = new Object[3 + resolvedArgs.length];
+
+    args[0] = MethodHandles.lookup();
+    args[1] = samMethodName;
+    args[2] = callSiteType;
+    System.arraycopy(resolvedArgs, 0, args, 3, resolvedArgs.length);
+
+    return args;
+  }
+
+  private Object convertToHostValue(Object value, Class<?> targetType) {
+    if (value == null) {
+      return null;
+    }
+
+    if (!(value instanceof ElementInfo)) {
+      return value;
+    }
+
+    ElementInfo ei = (ElementInfo) value;
+    String className = ei.getClassInfo().getName();
+
+    if (targetType == String.class) {
+      return ei.asString();
+    }
+    if (targetType == Byte.class || "java.lang.Byte".equals(className)) {
+      return ei.getByteField("value");
+    }
+    if (targetType == Short.class || "java.lang.Short".equals(className)) {
+      return ei.getShortField("value");
+    }
+    if (targetType == Integer.class || "java.lang.Integer".equals(className)) {
+      return ei.getIntField("value");
+    }
+    if (targetType == Long.class || "java.lang.Long".equals(className)) {
+      return ei.getLongField("value");
+    }
+    if (targetType == Float.class || "java.lang.Float".equals(className)) {
+      return ei.getFloatField("value");
+    }
+    if (targetType == Double.class || "java.lang.Double".equals(className)) {
+      return ei.getDoubleField("value");
+    }
+    if (targetType == Character.class || "java.lang.Character".equals(className)) {
+      return ei.getCharField("value");
+    }
+    if (targetType == Boolean.class || "java.lang.Boolean".equals(className)) {
+      return ei.getBooleanField("value");
+    }
+
+    return value;
+  }
+
+  private Object[] getDynamicArguments(ThreadInfo ti, StackFrame frame, MethodType callSiteType) {
+    Object[] values = frame.getArgumentsValues(ti, freeVariableTypes);
+    Object[] args = new Object[values.length];
+
+    for (int i = 0; i < values.length; i++) {
+      args[i] = convertToHostValue(values[i], callSiteType.parameterType(i));
+    }
+
+    return args;
+  }
+
+  private void pushDynamicResult(ThreadInfo ti, StackFrame frame, MethodType callSiteType, Object result) {
+    Class<?> returnType = callSiteType.returnType();
+
+    if (returnType == void.class) {
+      return;
+    }
+    if (returnType == boolean.class) {
+      frame.push(Boolean.TRUE.equals(result) ? 1 : 0);
+      return;
+    }
+    if (returnType == byte.class) {
+      frame.push(((Number) result).byteValue());
+      return;
+    }
+    if (returnType == short.class) {
+      frame.push(((Number) result).shortValue());
+      return;
+    }
+    if (returnType == char.class) {
+      frame.push((Character) result);
+      return;
+    }
+    if (returnType == int.class) {
+      frame.push(((Number) result).intValue());
+      return;
+    }
+    if (returnType == long.class) {
+      frame.pushLong(((Number) result).longValue());
+      return;
+    }
+    if (returnType == float.class) {
+      frame.push(Types.floatToInt(((Number) result).floatValue()));
+      return;
+    }
+    if (returnType == double.class) {
+      frame.pushLong(Types.doubleToLong(((Number) result).doubleValue()));
+      return;
+    }
+    if (result == null) {
+      frame.pushRef(MJIEnv.NULL);
+      return;
+    }
+    if (returnType == String.class) {
+      frame.pushRef(ti.getHeap().newString((String) result, ti).getObjectRef());
+      return;
+    }
+
+    throw new UnsupportedOperationException("Unsupported invokedynamic return type: " + returnType.getName());
+  }
+
   private Instruction executeDynamicBootstrap(ThreadInfo ti, StackFrame frame, BootstrapMethodInfo bmi) {
-   // TODO : work to be done here later
-    return null;
+    MethodType callSiteType = MethodType.fromMethodDescriptorString(bmi.getDynamicDescriptor(), getHostClassLoader());
+    Object[] dynamicArgs = getDynamicArguments(ti, frame, callSiteType);
+
+    try {
+      Class<?> bootstrapClass = Class.forName(normalizeClassName(bmi.getDynamicClassName()), true, getHostClassLoader());
+      Method bootstrapMethod = findBootstrapMethod(bootstrapClass, bmi);
+      CallSite callSite = (CallSite) bootstrapMethod.invoke(null, getBootstrapArguments(bmi, callSiteType));
+      MethodHandle target = callSite.getTarget();
+      Object result = target.invokeWithArguments(dynamicArgs);
+
+      frame.pop(freeVariableSize);
+      pushDynamicResult(ti, frame, callSiteType, result);
+      return getNext(ti);
+
+    } catch (Throwable t) {
+      throw new RuntimeException("failed to execute dynamic bootstrap for " + bmi.getDynamicMethodName(), t);
+    }
   }
   @Override
   public Instruction execute (ThreadInfo ti) {

--- a/src/tests/java11/DynamicBootstrapSupport.java
+++ b/src/tests/java11/DynamicBootstrapSupport.java
@@ -1,0 +1,56 @@
+package java11;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public final class DynamicBootstrapSupport {
+  private DynamicBootstrapSupport() {
+  }
+
+  public static CallSite bootstrapInt(MethodHandles.Lookup lookup, String name, MethodType type)
+      throws NoSuchMethodException, IllegalAccessException {
+    return new ConstantCallSite(
+        lookup.findStatic(DynamicBootstrapSupport.class, "returnFortyTwo", type));
+  }
+
+  public static CallSite bootstrapString(MethodHandles.Lookup lookup, String name, MethodType type)
+      throws NoSuchMethodException, IllegalAccessException {
+    return new ConstantCallSite(
+        lookup.findStatic(DynamicBootstrapSupport.class, "prefix", type));
+  }
+
+  public static CallSite bootstrapStringWithConstant(
+      MethodHandles.Lookup lookup, String name, MethodType type, String prefix)
+      throws NoSuchMethodException, IllegalAccessException {
+    return new ConstantCallSite(
+        MethodHandles.insertArguments(
+            lookup.findStatic(DynamicBootstrapSupport.class, "prefixWithConstant",
+                MethodType.methodType(String.class, String.class, String.class)),
+            0,
+            prefix).asType(type));
+  }
+
+  public static CallSite bootstrapDouble(MethodHandles.Lookup lookup, String name, MethodType type)
+      throws NoSuchMethodException, IllegalAccessException {
+    return new ConstantCallSite(
+        lookup.findStatic(DynamicBootstrapSupport.class, "describeDouble", type));
+  }
+
+  public static int returnFortyTwo() {
+    return 42;
+  }
+
+  public static String prefix(String value) {
+    return "prefix:" + value;
+  }
+
+  public static String prefixWithConstant(String prefix, String value) {
+    return prefix + value;
+  }
+
+  public static String describeDouble(double value) {
+    return "double:" + value;
+  }
+}

--- a/src/tests/java11/InvokeDynamicBootstrapTest.java
+++ b/src/tests/java11/InvokeDynamicBootstrapTest.java
@@ -1,0 +1,166 @@
+package java11;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.nio.file.Paths;
+
+public class InvokeDynamicBootstrapTest extends TestJPF {
+  private static final String GENERATED_CLASS_NAME = "java11.gen.DynamicBootstrapSubject";
+  private static final String GENERATED_INTERNAL_NAME = "java11/gen/DynamicBootstrapSubject";
+  private static final String GENERATED_OUTPUT_DIR = "build/tests-generated";
+
+  @Test
+  public void testDynamicBootstrapWithoutArguments() throws Exception {
+    ensureGeneratedClass();
+
+    if (verifyNoPropertyViolation("+classpath=" + GENERATED_OUTPUT_DIR + ",build/tests")) {
+      Class<?> cls = Class.forName(GENERATED_CLASS_NAME);
+      Method method = cls.getMethod("callInt");
+      Object result = method.invoke(null);
+
+      assertEquals(42, ((Integer) result).intValue());
+    }
+  }
+
+  @Test
+  public void testDynamicBootstrapWithStringArgument() throws Exception {
+    ensureGeneratedClass();
+
+    if (verifyNoPropertyViolation("+classpath=" + GENERATED_OUTPUT_DIR + ",build/tests")) {
+      Class<?> cls = Class.forName(GENERATED_CLASS_NAME);
+      Method method = cls.getMethod("callString", String.class);
+      Object result = method.invoke(null, "hello");
+
+      assertEquals("prefix:hello", result);
+    }
+  }
+
+  @Test
+  public void testDynamicBootstrapWithStaticBootstrapArgument() throws Exception {
+    ensureGeneratedClass();
+
+    if (verifyNoPropertyViolation("+classpath=" + GENERATED_OUTPUT_DIR + ",build/tests")) {
+      Class<?> cls = Class.forName(GENERATED_CLASS_NAME);
+      Method method = cls.getMethod("callStringWithConstant", String.class);
+      Object result = method.invoke(null, "hello");
+
+      assertEquals("constant:hello", result);
+    }
+  }
+
+  @Test
+  public void testDynamicBootstrapWithDoubleArgument() throws Exception {
+    ensureGeneratedClass();
+
+    if (verifyNoPropertyViolation("+classpath=" + GENERATED_OUTPUT_DIR + ",build/tests")) {
+      Class<?> cls = Class.forName(GENERATED_CLASS_NAME);
+      Method method = cls.getMethod("callDouble", double.class);
+      Object result = method.invoke(null, 3.5d);
+
+      assertEquals("double:3.5", result);
+    }
+  }
+
+  private static void ensureGeneratedClass() {
+    if (isJPFRun()) {
+      return;
+    }
+
+    try {
+      java.nio.file.Path dir = Paths.get(GENERATED_OUTPUT_DIR);
+      java.nio.file.Path classFile = dir.resolve(GENERATED_INTERNAL_NAME + ".class");
+      java.nio.file.Files.createDirectories(classFile.getParent());
+      java.nio.file.Files.write(classFile, createDynamicBootstrapClass());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static byte[] createDynamicBootstrapClass() {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V11, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, GENERATED_INTERNAL_NAME, null,
+        "java/lang/Object", null);
+
+    MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    mv.visitCode();
+    mv.visitVarInsn(Opcodes.ALOAD, 0);
+    mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    mv.visitInsn(Opcodes.RETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+
+    Handle intBootstrap = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java11/DynamicBootstrapSupport",
+        "bootstrapInt",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        false);
+
+    mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "callInt", "()I", null, null);
+    mv.visitCode();
+    mv.visitInvokeDynamicInsn("run", "()I", intBootstrap);
+    mv.visitInsn(Opcodes.IRETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+
+    Handle stringBootstrap = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java11/DynamicBootstrapSupport",
+        "bootstrapString",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        false);
+
+    mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "callString",
+        "(Ljava/lang/String;)Ljava/lang/String;", null, null);
+    mv.visitCode();
+    mv.visitVarInsn(Opcodes.ALOAD, 0);
+    mv.visitInvokeDynamicInsn("format", "(Ljava/lang/String;)Ljava/lang/String;", stringBootstrap);
+    mv.visitInsn(Opcodes.ARETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+
+    Handle stringConstantBootstrap = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java11/DynamicBootstrapSupport",
+        "bootstrapStringWithConstant",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;)Ljava/lang/invoke/CallSite;",
+        false);
+
+    mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "callStringWithConstant",
+        "(Ljava/lang/String;)Ljava/lang/String;", null, null);
+    mv.visitCode();
+    mv.visitVarInsn(Opcodes.ALOAD, 0);
+    mv.visitInvokeDynamicInsn("formatConstant", "(Ljava/lang/String;)Ljava/lang/String;",
+        stringConstantBootstrap, "constant:");
+    mv.visitInsn(Opcodes.ARETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+
+    Handle doubleBootstrap = new Handle(
+        Opcodes.H_INVOKESTATIC,
+        "java11/DynamicBootstrapSupport",
+        "bootstrapDouble",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+        false);
+
+    mv = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "callDouble", "(D)Ljava/lang/String;",
+        null, null);
+    mv.visitCode();
+    mv.visitVarInsn(Opcodes.DLOAD, 0);
+    mv.visitInvokeDynamicInsn("describe", "(D)Ljava/lang/String;", doubleBootstrap);
+    mv.visitInsn(Opcodes.ARETURN);
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+}


### PR DESCRIPTION
Summary
This PR implements a baseline execution path for generic invokedynamic bootstrap methods (BMType.DYNAMIC) on the java-17 branch. It addresses the current limitation where JPF only handles hardcoded cases like Lambdas or StringConcat, providing a foundation for broader Java 11/17 support.

Key Changes
Core Logic: Implemented INVOKEDYNAMIC.executeDynamicBootstrap(...) to handle a minimal supported subset of dynamic calls.

Regression Tests: Added InvokeDynamicBootstrapTest using ASM to generate invokedynamic call sites that standard Java compilers typically don't produce.

Technical Coverage:

Support for no-arg and String argument dynamic bootstrap call sites.

Handling of bootstrap static arguments.

Proper management of double (double-slot) stack values.

Record Fix: Restored java.lang.runtime.ObjectMethods.bootstrap to the dedicated RECORDS path to prevent interference with existing record behavior.

Scope & Limitations
To keep this initial PR reviewable, the scope is restricted to:

Static bootstrap methods.

CallSite returns (specifically ConstantCallSite).

Conversion for primitives, boxed primitives, and String on the exercised paths.

Testing
Verified via:

java11.InvokeDynamicBootstrapTest

java11.DynamicBootstrapSupport

Full local suite: ./gradlew test

Context
While JPF has special-case handling for specific bootstrap-based features, generic dynamic bootstrap execution was missing. This PR provides the necessary plumbing and testing infrastructure to begin supporting more complex Java 11+ bootstrap scenarios.