### PR TITLE
fix: normalize permitted subclass names to dot notation in setPermittedSubclass

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -65,7 +65,7 @@ public class JVMClassInfo extends ClassInfo {
 
     @Override
     public void setPermittedSubclass(ClassFile cf, Object tag, int index, String subclassName) {
-      permittedSubclassNames[index] = subclassName;
+      permittedSubclassNames[index] = Types.getClassNameFromTypeName(subclassName);
     }
 
     @Override


### PR DESCRIPTION
Fixes part of #605

setPermittedSubclass() was storing class names in slash notation
(e.g. gov/nasa/jpf/...) instead of dot notation (gov.nasa.jpf...).

This bug was pointed out in the issue comments by @Mahmoud-Khawaja.

The fix applies Types.getClassNameFromTypeName() which is the same
approach already used in setInterface() for consistency.