### PR TITLE
Add missing Dockerfile to java-17 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:11-jdk-jammy
+
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /home/jpf-core
+
+WORKDIR /home/jpf-core
+
+RUN git config --global --add safe.directory /home/jpf-core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  jpf-dev:
+    image: jpf-core
+    build:
+      context: .
+    working_dir: /home/jpf-core
+    volumes:
+      - .:/home/jpf-core
+      - ~/.gradle:/root/.gradle
+    entrypoint: bash


### PR DESCRIPTION
### Description
The experimental `java-17` branch was currently missing a `Dockerfile` for containerized testing and development, which is present in the `main` branch.

So I added `Dockerfile` and `docker-compose.yml` in it.