### PR TITLE
fix: correct \u0002 (TAG_CONST) handling in invokedynamic string concat (#619)

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -225,10 +225,24 @@ public class JVMClassInfo extends ClassInfo {
 
       assert (enclosingLambdaCls!=null);
 
-      String bmArg = cf.getBmArgString(cpArgs[0]);
+      // Plain StringConcatFactory.makeConcat (e.g. compiled with
+      // -XDstringConcat=indy) has zero static bootstrap args -- no recipe,
+      // no constants. cpArgs[0] would throw ArrayIndexOutOfBoundsException.
+      // See issue #619, bug 3.
+      String bmArg = cpArgs.length > 0 ? cf.getBmArgString(cpArgs[0]) : "";
 
       setBootstrapMethodInfo(enclosingLambdaCls, mth, parameters, idx, refKind, descriptor, bmArg,
               BootstrapMethodInfo.BMType.STRING_CONCATENATION);
+
+      // Resolve all bootstrap static args (recipe + constants) so that
+      // extractConstants() can later return the constants referenced by
+      // \u0002 (TAG_CONST) markers in the recipe. Without this, constants
+      // are silently dropped -- see issue #619.
+      Object[] resolvedArgs = new Object[cpArgs.length];
+      for (int i = 0; i < cpArgs.length; i++) {
+        resolvedArgs[i] = cf.getConstantValue(cpArgs[i]);
+      }
+      bootstrapMethods[idx].setResolvedArgs(resolvedArgs);
     }
     
     // helper method for setBootstrapMethod()

--- a/src/main/gov/nasa/jpf/vm/JPFStringConcatHelper.java
+++ b/src/main/gov/nasa/jpf/vm/JPFStringConcatHelper.java
@@ -42,6 +42,7 @@ public class JPFStringConcatHelper {
 
         StringBuilder sb = new StringBuilder();
         int argIndex = 0;
+        int constIndex = 0;
 
         for (int i = 0; i < recipe.length(); i++) {
             char c = recipe.charAt(i);
@@ -51,12 +52,11 @@ public class JPFStringConcatHelper {
                     appendValue(sb, args[argIndex], argTypes[argIndex]);
                     argIndex++;
                 }
-            } else if (c == CONST_PLACEHOLDER && i + 1 < recipe.length()) {
-                i++; // Move to next character
-                int constIndex = recipe.charAt(i) - 1;
-                if (constIndex >= 0 && constIndex < constants.length) {
+            } else if (c == CONST_PLACEHOLDER) {
+                if (constIndex < constants.length) {
                     Object constant = constants[constIndex];
                     sb.append(constant != null ? constant : "null");
+                    constIndex++;
                 }
             } else {
                 sb.append(c);

--- a/src/tests/java11/StringConcatConstantTest.java
+++ b/src/tests/java11/StringConcatConstantTest.java
@@ -1,0 +1,59 @@
+package java11;
+
+import org.junit.Test;
+import gov.nasa.jpf.util.test.TestJPF;
+
+/**
+ * Regression tests for issue #619: invokedynamic string concat bugs.
+ *
+ * Bug 1: JPFStringConcatHelper.concatenate() misread the char after \u0002 as a
+ *        1-based constant index, dropping the constant and the following recipe char.
+ * Bug 2: JVMClassInfo.stringConcatenation() never called setResolvedArgs(), so the
+ *        constants array was always empty.
+ */
+public class StringConcatConstantTest extends TestJPF {
+
+  @Test
+  public void testConstantWithTagCharIsPreserved() {
+    if (verifyNoPropertyViolation()) {
+      // "\u0001hi" contains a TAG_ARG char so javac cannot inline it into the
+      // recipe -- it emits it as a bootstrap constant (\u0002 TAG_CONST marker).
+      // Before the fix: constant was dropped, "world" was also dropped.
+      String name = "world";
+      String s = "\u0001hi" + name;
+      assertEquals("\u0001hiworld", s);
+    }
+  }
+
+  @Test
+  public void testConstantPrecedesArgument() {
+    if (verifyNoPropertyViolation()) {
+      // Constant \u0002x forces TAG_CONST; the variable follows as TAG_ARG.
+      // Verifies that both the constant AND the argument appear in the result.
+      String arg = "end";
+      String s = "\u0002x" + arg;
+      assertEquals("\u0002xend", s);
+    }
+  }
+
+  @Test
+  public void testMultipleConstantsAndArgs() {
+    if (verifyNoPropertyViolation()) {
+      // Two variables interleaved with two constants that contain tag chars.
+      String a = "foo";
+      String b = "bar";
+      String s = "\u0001prefix" + a + "\u0002mid" + b;
+      assertEquals("\u0001prefixfoo\u0002midbar", s);
+    }
+  }
+
+  @Test
+  public void testPlainConcatStillWorks() {
+    if (verifyNoPropertyViolation()) {
+      // Ordinary concat (no TAG_CONST) must continue to work after the fix.
+      String name = "world";
+      String s = "Hello " + name + "!";
+      assertEquals("Hello world!", s);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #619

Three bugs fixed in StringConcatFactory invokedynamic support on the call-site-generation branch:

**Bug 1 — Decoder misreads \u0002 as a 1-based index**
`JPFStringConcatHelper.concatenate()` did `i++` after seeing `\u0002`, then read `recipe.charAt(i) - 1` as a constant index. This dropped the following recipe character and computed a garbage index, silently losing both the constant and the next literal/marker. Fixed by consuming constants sequentially via a `constIndex` counter — the same pattern `argIndex` already uses for `\u0001`.

**Bug 2 — Constants array always empty**
`JVMClassInfo.stringConcatenation()` only stored `cpArgs[0]` (the recipe) and never called `setResolvedArgs()`, so `constants[]` was always empty. Fixed by resolving all bootstrap static args after `setBootstrapMethodInfo()`.

**Bug 3 — ArrayIndexOutOfBoundsException on plain makeConcat**
`stringConcatenation()` accessed `cpArgs[0]` unconditionally, but `StringConcatFactory.makeConcat` (emitted with `-XDstringConcat=indy`) has zero static args. Fixed with a length guard before accessing `cpArgs[0]`.

**Tests added:** `StringConcatConstantTest` with 4 regression cases covering bugs 1 and 2. Bug 3 verified manually via `javac -XDstringConcat=indy` + JPF run.