### PR TITLE
Fix: Record component generic signatures and Class.isRecord()

### DIFF
--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -407,4 +407,5 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   }
 
   public native boolean isRecord();
+  public native java.lang.reflect.RecordComponent[] getRecordComponents();
 }

--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -406,7 +406,5 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
     return module;
   }
 
-  public boolean isRecord() {
-    return false;
-  }
+  public native boolean isRecord();
 }

--- a/src/classes/modules/java.base/java/lang/reflect/RecordComponent.java
+++ b/src/classes/modules/java.base/java/lang/reflect/RecordComponent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package java.lang.reflect;
+
+import java.lang.annotation.Annotation;
+
+public final class RecordComponent {
+  int regIdx;        // link to the corresponding RecordComponentInfo
+  Class<?> clazz;    // the record class that declared this component
+  String name;       // deferred set by the NativePeer
+
+  public native String getName();
+  public native Class<?> getType();
+  public native String getGenericSignature();
+  public native java.lang.reflect.Method getAccessor();
+  public native Annotation[] getAnnotations();
+  public native Annotation[] getDeclaredAnnotations();
+}

--- a/src/classes/modules/java.base/java/lang/reflect/RecordComponent.java
+++ b/src/classes/modules/java.base/java/lang/reflect/RecordComponent.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2014, United States Government, as represented by the
- * Administrator of the National Aeronautics and Space Administration.
+ * Copyright (C) 2026, Darshan R
  * All rights reserved.
  *
  * The Java Pathfinder core (jpf-core) platform is licensed under the

--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -251,12 +251,10 @@ public class JVMClassInfo extends ClassInfo {
       if (attrName.equals(ClassFile.SIGNATURE_ATTR)) {
         cf.parseSignatureAttr(this, rci);
       }
-      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_ANNOTATIONS_ATTR)
-              || attrName.equals(ClassFile.RUNTIME_INVISIBLE_ANNOTATIONS_ATTR)) {
+      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_ANNOTATIONS_ATTR)) {
         cf.parseAnnotationsAttr(this, rci);
       }
-      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_TYPE_ANNOTATIONS_ATTR)
-              || attrName.equals(ClassFile.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS_ATTR)) {
+      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_TYPE_ANNOTATIONS_ATTR)) {
         cf.parseTypeAnnotationsAttr(this, rci);
       }
     }

--- a/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
+++ b/src/main/gov/nasa/jpf/jvm/JVMClassInfo.java
@@ -246,39 +246,19 @@ public class JVMClassInfo extends ClassInfo {
     public void setRecordComponentAttribute(ClassFile cf, Object tag, int componentIndex, int attrIndex, String attrName, int attrLength) {
       RecordComponentInfo rci = JVMClassInfo.this.recordComponents[componentIndex];
 
-      String name = rci.getName();
-      String descriptor = rci.getDescriptor();
-      String signature = rci.getSignature();
-      AnnotationInfo[] annotations = rci.getAnnotations();
-      TypeAnnotationInfo[] typeAnnotations = rci.getTypeAnnotations();
-
+      // RecordComponentInfo now extends InfoObject and implements GenericSignatureHolder,
+      // so the parse callbacks populate rci directly instead of silently no-op'ing.
       if (attrName.equals(ClassFile.SIGNATURE_ATTR)) {
-        // Use the signature consumer pattern
         cf.parseSignatureAttr(this, rci);
-        signature = rci.getSignature();
       }
-      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_ANNOTATIONS_ATTR)) {
-        annotations = new AnnotationInfo[0]; // Initialize or preserve existing
+      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_ANNOTATIONS_ATTR)
+              || attrName.equals(ClassFile.RUNTIME_INVISIBLE_ANNOTATIONS_ATTR)) {
         cf.parseAnnotationsAttr(this, rci);
-        annotations = rci.getAnnotations();
       }
-      else if (attrName.equals(ClassFile.RUNTIME_INVISIBLE_ANNOTATIONS_ATTR)) {
-        cf.parseAnnotationsAttr(this, rci);
-        // we might need to merge with existing annotations
-      }
-      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_TYPE_ANNOTATIONS_ATTR)) {
-        // Set up for type annotation parsing
-        typeAnnotations = new TypeAnnotationInfo[0];
-        cf.parseTypeAnnotationsAttr(this, rci);
-        typeAnnotations = rci.getTypeAnnotations();
-      }
-      else if (attrName.equals(ClassFile.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS_ATTR)) {
+      else if (attrName.equals(ClassFile.RUNTIME_VISIBLE_TYPE_ANNOTATIONS_ATTR)
+              || attrName.equals(ClassFile.RUNTIME_INVISIBLE_TYPE_ANNOTATIONS_ATTR)) {
         cf.parseTypeAnnotationsAttr(this, rci);
       }
-
-      // a new RecordComponentInfo with all updated attributes
-      JVMClassInfo.this.recordComponents[componentIndex] =
-              new RecordComponentInfo(name, descriptor, signature, annotations, typeAnnotations);
     }
 
     @Override

--- a/src/main/gov/nasa/jpf/vm/RecordComponentInfo.java
+++ b/src/main/gov/nasa/jpf/vm/RecordComponentInfo.java
@@ -1,23 +1,29 @@
 package gov.nasa.jpf.vm;
 
 /**
- * Class representing a Record component in a Java 17+ record class
+ * Class representing a Record component in a Java 17+ record class.
+ *
+ * Extends InfoObject and implements GenericSignatureHolder so that classfile
+ * parse callbacks (setSignature / setAnnotation / setAnnotationsDone) populate
+ * this object directly, the same way they do for FieldInfo and MethodInfo.
+ * Without this, generic signatures and annotations are silently dropped.
  */
-
-public class RecordComponentInfo {
+public class RecordComponentInfo extends InfoObject implements GenericSignatureHolder {
     private final String name;
     private final String descriptor;
-    private final String signature;
-    private final AnnotationInfo[] annotations;
-    private final TypeAnnotationInfo[] typeAnnotations;
+    private String signature;
 
     public RecordComponentInfo(String name, String descriptor, String signature,
-                           AnnotationInfo[] annotations, TypeAnnotationInfo[] typeAnnotations) {
+                               AnnotationInfo[] annotations, TypeAnnotationInfo[] typeAnnotations) {
         this.name = name;
         this.descriptor = descriptor;
         this.signature = signature;
-        this.annotations = annotations;
-        this.typeAnnotations = typeAnnotations;
+        if (annotations != null) {
+            this.annotations = annotations;
+        }
+        if (typeAnnotations != null) {
+            this.typeAnnotations = typeAnnotations;
+        }
     }
 
     public String getName() {
@@ -28,15 +34,17 @@ public class RecordComponentInfo {
         return descriptor;
     }
 
-    public String getSignature() {
+    @Override
+    public String getGenericSignature() {
         return signature;
     }
 
-    public AnnotationInfo[] getAnnotations() {
-        return annotations;
+    @Override
+    public void setGenericSignature(String signature) {
+        this.signature = signature;
     }
 
-    public TypeAnnotationInfo[] getTypeAnnotations() {
-        return typeAnnotations;
+    public String getSignature() {
+        return signature;
     }
 }

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -83,7 +83,13 @@ public class JPF_java_lang_Class extends NativePeer {
     ClassInfo ci = env.getReferredClassInfo( robj);
     return ci.isInterface();
   }
-  
+
+  @MJI
+  public boolean isRecord____Z (MJIEnv env, int robj){
+    ClassInfo ci = env.getReferredClassInfo(robj);
+    return ci.isRecord();
+  }
+
   @MJI
   public boolean isAssignableFrom__Ljava_lang_Class_2__Z (MJIEnv env, int rcls,
                                                               int r1) {

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -91,6 +91,33 @@ public class JPF_java_lang_Class extends NativePeer {
   }
 
   @MJI
+  public int getRecordComponents_____3Ljava_lang_reflect_RecordComponent_2 (MJIEnv env, int objRef) {
+    ClassInfo rci = getInitializedClassInfo(env, "java.lang.reflect.RecordComponent");
+    if (rci == null) {
+      env.repeatInvocation();
+      return MJIEnv.NULL;
+    }
+    ClassInfo ci = env.getReferredClassInfo(objRef);
+    if (!ci.isRecord()) {
+      return MJIEnv.NULL;
+    }
+    RecordComponentInfo[] components = ci.getRecordComponents();
+    if (components == null) {
+      return MJIEnv.NULL;
+    }
+    int aref = env.newObjectArray("Ljava/lang/reflect/RecordComponent;", components.length);
+    for (int i = 0; i < components.length; i++) {
+      RecordComponentInfo rcInfo = components[i];
+      int rcRef = env.newObject(rci);
+      ElementInfo ei = env.getModifiableElementInfo(rcRef);
+      ei.setIntField("regIdx", i);
+      ei.setReferenceField("clazz", objRef);
+      env.setReferenceArrayElement(aref, i, rcRef);
+    }
+    return aref;
+  }
+
+  @MJI
   public boolean isAssignableFrom__Ljava_lang_Class_2__Z (MJIEnv env, int rcls,
                                                               int r1) {
     ElementInfo sei1 = env.getStaticElementInfo(rcls);

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
@@ -18,6 +18,9 @@ import gov.nasa.jpf.vm.MJIEnv;
 import gov.nasa.jpf.vm.NativePeer;
 import gov.nasa.jpf.vm.RecordComponentInfo;
 import gov.nasa.jpf.vm.ThreadInfo;
+import gov.nasa.jpf.vm.AnnotationInfo;
+import gov.nasa.jpf.vm.MethodInfo;
+import gov.nasa.jpf.vm.JPF_java_lang_reflect_Method;
 import gov.nasa.jpf.vm.Types;
 
 /**
@@ -73,6 +76,28 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
   }
 
   @MJI
+  public int getAccessor____Ljava_lang_reflect_Method_2(MJIEnv env, int objRef) {
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return MJIEnv.NULL;
+
+    // get the record class
+    int classRef = env.getReferenceField(objRef, "clazz");
+    if (classRef == MJIEnv.NULL) return MJIEnv.NULL;
+    ClassInfo recordCI = env.getReferredClassInfo(classRef);
+
+    // accessor method has same name as component, no args, returns component type
+    String accessorSignature = rci.getName() + "()" + rci.getDescriptor();
+    MethodInfo mi = recordCI.getMethod(accessorSignature, false);
+    if (mi == null) return MJIEnv.NULL;
+
+    // get ClassInfo for java.lang.reflect.Method (needed by createMethodObject)
+    ClassInfo methodCI = ClassLoaderInfo.getSystemResolvedClassInfo("java.lang.reflect.Method");
+    if (methodCI == null) return MJIEnv.NULL;
+
+    return JPF_java_lang_reflect_Method.createMethodObject(env, methodCI, mi);
+  }
+
+  @MJI
   public int getGenericSignature____Ljava_lang_String_2(MJIEnv env, int objRef) {
     RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
     if (rci == null) return MJIEnv.NULL;
@@ -82,12 +107,19 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
 
   @MJI
   public int getAnnotations_____3Ljava_lang_annotation_Annotation_2(MJIEnv env, int objRef) {
-    // Return empty array for now - annotation support can be added later
-    return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    AnnotationInfo[] ai = rci.getAnnotations();
+    if (ai == null || ai.length == 0) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    return env.newAnnotationProxies(ai);
   }
 
   @MJI
   public int getDeclaredAnnotations_____3Ljava_lang_annotation_Annotation_2(MJIEnv env, int objRef) {
-    return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    AnnotationInfo[] ai = rci.getDeclaredAnnotations();
+    if (ai == null || ai.length == 0) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+    return env.newAnnotationProxies(ai);
   }
 }

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the
+ * License at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+package gov.nasa.jpf.vm;
+
+import gov.nasa.jpf.annotation.MJI;
+import gov.nasa.jpf.vm.ClassInfo;
+import gov.nasa.jpf.vm.ClassLoaderInfo;
+import gov.nasa.jpf.vm.ElementInfo;
+import gov.nasa.jpf.vm.MJIEnv;
+import gov.nasa.jpf.vm.NativePeer;
+import gov.nasa.jpf.vm.RecordComponentInfo;
+import gov.nasa.jpf.vm.ThreadInfo;
+import gov.nasa.jpf.vm.Types;
+
+/**
+ * Native peer for java.lang.reflect.RecordComponent.
+ * Provides reflection access to record component metadata stored in RecordComponentInfo.
+ *
+ * regIdx stores the component index within the declaring record class.
+ * We recover the declaring ClassInfo via the class of the RecordComponent object itself.
+ */
+public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
+
+  private static RecordComponentInfo getRecordComponentInfo(MJIEnv env, int objRef) {
+    // regIdx is the index of this component in the record's component array
+    int regIdx = env.getIntField(objRef, "regIdx");
+    // get the ElementInfo for this RecordComponent object
+    ElementInfo ei = env.getElementInfo(objRef);
+    // get the ClassInfo of the class that declared this record component
+    // by walking up to find the enclosing record class via the class object reference
+    ClassInfo ci = ei.getClassInfo();
+    // ci is java.lang.reflect.RecordComponent - we need the record class itself
+    // stored implicitly: we resolve via the thread's current class loader
+    // We store classRef in the object to avoid this lookup each time
+    int classRef = env.getReferenceField(objRef, "clazz");
+    if (classRef == MJIEnv.NULL) {
+      return null;
+    }
+    ClassInfo recordCI = env.getReferredClassInfo(classRef);
+    RecordComponentInfo[] components = recordCI.getRecordComponents();
+    if (components == null || regIdx < 0 || regIdx >= components.length) {
+      return null;
+    }
+    return components[regIdx];
+  }
+
+  @MJI
+  public int getType____Ljava_lang_Class_2(MJIEnv env, int objRef) {
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return MJIEnv.NULL;
+    ThreadInfo ti = env.getThreadInfo();
+    ClassInfo ci = ClassLoaderInfo.getCurrentResolvedClassInfo(
+        Types.getTypeName(rci.getDescriptor()));
+    if (!ci.isRegistered()) {
+      ci.registerClass(ti);
+    }
+    return ci.getClassObjectRef();
+  }
+
+  @MJI
+  public int getName____Ljava_lang_String_2(MJIEnv env, int objRef) {
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return MJIEnv.NULL;
+    return env.newString(rci.getName());
+  }
+
+  @MJI
+  public int getGenericSignature____Ljava_lang_String_2(MJIEnv env, int objRef) {
+    RecordComponentInfo rci = getRecordComponentInfo(env, objRef);
+    if (rci == null) return MJIEnv.NULL;
+    String sig = rci.getSignature();
+    return sig != null ? env.newString(sig) : MJIEnv.NULL;
+  }
+
+  @MJI
+  public int getAnnotations_____3Ljava_lang_annotation_Annotation_2(MJIEnv env, int objRef) {
+    // Return empty array for now - annotation support can be added later
+    return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+  }
+
+  @MJI
+  public int getDeclaredAnnotations_____3Ljava_lang_annotation_Annotation_2(MJIEnv env, int objRef) {
+    return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
+  }
+}

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
@@ -90,8 +90,6 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
     MethodInfo mi = recordCI.getMethod(accessorSignature, false);
     if (mi == null) return MJIEnv.NULL;
 
-    // get ClassInfo for java.lang.reflect.Method - must be initialized, not just resolved
-    // same pattern as getEnclosingConstructor in JPF_java_lang_Class
     ClassInfo methodCI = JPF_java_lang_Class.getInitializedClassInfo(env, "java.lang.reflect.Method");
     if (methodCI == null) {
       env.repeatInvocation();

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
@@ -90,9 +90,13 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
     MethodInfo mi = recordCI.getMethod(accessorSignature, false);
     if (mi == null) return MJIEnv.NULL;
 
-    // get ClassInfo for java.lang.reflect.Method (needed by createMethodObject)
-    ClassInfo methodCI = ClassLoaderInfo.getSystemResolvedClassInfo("java.lang.reflect.Method");
-    if (methodCI == null) return MJIEnv.NULL;
+    // get ClassInfo for java.lang.reflect.Method - must be initialized, not just resolved
+    // same pattern as getEnclosingConstructor in JPF_java_lang_Class
+    ClassInfo methodCI = JPF_java_lang_Class.getInitializedClassInfo(env, "java.lang.reflect.Method");
+    if (methodCI == null) {
+      env.repeatInvocation();
+      return MJIEnv.NULL;
+    }
 
     return JPF_java_lang_reflect_Method.createMethodObject(env, methodCI, mi);
   }
@@ -111,7 +115,12 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
     if (rci == null) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
     AnnotationInfo[] ai = rci.getAnnotations();
     if (ai == null || ai.length == 0) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
-    return env.newAnnotationProxies(ai);
+    try {
+      return env.newAnnotationProxies(ai);
+    } catch (gov.nasa.jpf.vm.ClinitRequired x) {
+      env.handleClinitRequest(x.getRequiredClassInfo());
+      return MJIEnv.NULL;
+    }
   }
 
   @MJI
@@ -120,6 +129,11 @@ public class JPF_java_lang_reflect_RecordComponent extends NativePeer {
     if (rci == null) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
     AnnotationInfo[] ai = rci.getDeclaredAnnotations();
     if (ai == null || ai.length == 0) return env.newObjectArray("Ljava/lang/annotation/Annotation;", 0);
-    return env.newAnnotationProxies(ai);
+    try {
+      return env.newAnnotationProxies(ai);
+    } catch (gov.nasa.jpf.vm.ClinitRequired x) {
+      env.handleClinitRequest(x.getRequiredClassInfo());
+      return MJIEnv.NULL;
+    }
   }
 }

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_reflect_RecordComponent.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2014, United States Government, as represented by the
- * Administrator of the National Aeronautics and Space Administration.
+ * Copyright (C) 2026, Darshan R
  * All rights reserved.
  *
  * The Java Pathfinder core (jpf-core) platform is licensed under the

--- a/src/tests/gov/nasa/jpf/jvm/BoxRecord.java
+++ b/src/tests/gov/nasa/jpf/jvm/BoxRecord.java
@@ -1,0 +1,10 @@
+package gov.nasa.jpf.jvm;
+
+import java.util.List;
+
+/**
+ * Test record with generic components used to verify that
+ * record component generic signatures are preserved during
+ * class-file parsing.
+ */
+record BoxRecord<T>(T value, List<String> items) {}

--- a/src/tests/gov/nasa/jpf/jvm/ClassInfoTest.java
+++ b/src/tests/gov/nasa/jpf/jvm/ClassInfoTest.java
@@ -23,6 +23,7 @@ import gov.nasa.jpf.vm.ClassInfo;
 import gov.nasa.jpf.vm.ClassParseException;
 import gov.nasa.jpf.vm.FieldInfo;
 import gov.nasa.jpf.vm.MethodInfo;
+import gov.nasa.jpf.vm.RecordComponentInfo;
 
 
 import java.io.File;
@@ -143,4 +144,38 @@ public class ClassInfoTest extends TestJPF {
     }
   }
 
+  @Test
+  public void testRecordComponentMetadataParsing() {
+    File file = new File("build/tests/gov/nasa/jpf/jvm/BoxRecord.class");
+
+    try {
+      ClassInfo ci = new NonResolvedClassInfo("gov.nasa.jpf.jvm.BoxRecord", file);
+
+      assert ci.isRecord() : "BoxRecord should be recognized as a record";
+
+      RecordComponentInfo[] comps = ci.getRecordComponents();
+      assert comps != null : "getRecordComponents() should not return null";
+      assert comps.length == 2 : "BoxRecord should have 2 components, got: " + comps.length;
+
+      // component 0: value (generic type T)
+      RecordComponentInfo value = comps[0];
+      assert "value".equals(value.getName()) : "first component should be 'value'";
+      assert value.getSignature() != null : "value should have generic signature, got null";
+      assert value.getSignature().contains("T") : "value signature should contain T, got: " + value.getSignature();
+
+      // component 1: items (List<String>)
+      RecordComponentInfo items = comps[1];
+      assert "items".equals(items.getName()) : "second component should be 'items'";
+      assert items.getSignature() != null : "items should have generic signature, got null";
+      assert items.getSignature().contains("String") : "items signature should contain String, got: " + items.getSignature();
+
+      System.out.println("-- record components");
+      for (RecordComponentInfo rci : comps) {
+        System.out.println(rci.getName() + " descriptor=" + rci.getDescriptor() + " signature=" + rci.getSignature());
+      }
+
+    } catch (ClassParseException cfx) {
+      fail("ClassParseException: " + cfx);
+    }
+  }
 }

--- a/src/tests/java17/records/RecordComponentReflectionTest.java
+++ b/src/tests/java17/records/RecordComponentReflectionTest.java
@@ -1,0 +1,60 @@
+package java17.records;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+import java.lang.reflect.RecordComponent;
+
+public class RecordComponentReflectionTest extends TestJPF {
+
+  record Point(int x, int y) {}
+  record Person(String name, int age) {}
+
+  @Test
+  public void testGetRecordComponents_returnsCorrectCount() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = Point.class.getRecordComponents();
+      assertNotNull(components);
+      assertEquals(2, components.length);
+    }
+  }
+
+  @Test
+  public void testGetRecordComponents_returnsCorrectNames() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = Point.class.getRecordComponents();
+      assertNotNull(components);
+      assertEquals("x", components[0].getName());
+      assertEquals("y", components[1].getName());
+    }
+  }
+
+  @Test
+  public void testGetRecordComponents_nonRecordReturnsNull() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = String.class.getRecordComponents();
+      assertNull(components);
+    }
+  }
+
+  @Test
+  public void testGetRecordComponents_multipleComponents() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = Person.class.getRecordComponents();
+      assertNotNull(components);
+      assertEquals(2, components.length);
+      assertEquals("name", components[0].getName());
+      assertEquals("age", components[1].getName());
+    }
+  }
+
+  // This will expose missing getType() peer if not implemented
+  @Test
+  public void testGetRecordComponents_correctTypes() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = Point.class.getRecordComponents();
+      assertNotNull(components);
+      assertEquals(int.class, components[0].getType());
+      assertEquals(int.class, components[1].getType());
+    }
+  }
+}

--- a/src/tests/java17/records/RecordComponentReflectionTest.java
+++ b/src/tests/java17/records/RecordComponentReflectionTest.java
@@ -87,6 +87,8 @@ public class RecordComponentReflectionTest extends TestJPF {
       java.lang.annotation.Annotation[] annotations = components[0].getAnnotations();
       assertNotNull(annotations);
       assertTrue(annotations.length > 0);
+      assertEquals(ComponentLabel.class, annotations[0].annotationType());
+      assertEquals("x-coord", ((ComponentLabel) annotations[0]).value());
     }
   }
 

--- a/src/tests/java17/records/RecordComponentReflectionTest.java
+++ b/src/tests/java17/records/RecordComponentReflectionTest.java
@@ -3,6 +3,7 @@ package java17.records;
 import gov.nasa.jpf.util.test.TestJPF;
 import org.junit.Test;
 import java.lang.reflect.RecordComponent;
+import java.lang.annotation.*;
 
 public class RecordComponentReflectionTest extends TestJPF {
 
@@ -57,4 +58,36 @@ public class RecordComponentReflectionTest extends TestJPF {
       assertEquals(int.class, components[1].getType());
     }
   }
+
+  @Test
+  public void testGetRecordComponents_getAccessor() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = Point.class.getRecordComponents();
+      assertNotNull(components);
+      java.lang.reflect.Method accessor = components[0].getAccessor();
+      assertNotNull(accessor);
+      assertEquals("x", accessor.getName());
+    }
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.RECORD_COMPONENT)
+  @interface ComponentLabel {
+    String value();
+  }
+
+  record AnnotatedPoint(@ComponentLabel("x-coord") int x, @ComponentLabel("y-coord") int y) {}
+
+  @Test
+  public void testGetRecordComponents_annotations() {
+    if (verifyNoPropertyViolation()) {
+      RecordComponent[] components = AnnotatedPoint.class.getRecordComponents();
+      assertNotNull(components);
+      assertEquals(2, components.length);
+      java.lang.annotation.Annotation[] annotations = components[0].getAnnotations();
+      assertNotNull(annotations);
+      assertTrue(annotations.length > 0);
+    }
+  }
+
 }


### PR DESCRIPTION
fix #624

Addresses two bugs and one missing feature noted by @Mahmoud-Khawaja:

**1: fix Class.isRecord()**
- Class.isRecord() was hardcoded to return false
- Now correctly delegates to ClassInfo.isRecord()

**2: preserve record component generic signatures**
- Generic signatures and annotations were silently dropped during classfile parsing
- Fixed by implementing setRecordComponentAttribute properly in JVMClassInfo.Initializer

**3: add Class.getRecordComponents() reflection support**
- New modeled java.lang.reflect.RecordComponent class
- Class.getRecordComponents() peer implementation
- JPF_java_lang_reflect_RecordComponent peer with getName(), getType(), getAccessor(), getAnnotations(), getDeclaredAnnotations()
- getAccessor() fully implemented via JPF_java_lang_reflect_Method.createMethodObject()
- Annotations wired through env.newAnnotationProxies() backed by RecordComponentInfo.getAnnotations()
- 7 tests covering count, names, types, accessor, annotations, and non-record null return

All tests pass, no regressions.