### PR TITLE
Fix boxed Float and Double string concatenation (#626)

### DIFF
--- a/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
+++ b/src/main/gov/nasa/jpf/jvm/bytecode/INVOKEDYNAMIC.java
@@ -297,8 +297,8 @@ public class INVOKEDYNAMIC extends Instruction {
       case "java.lang.Short":   return ei.getShortField("value");
       case "java.lang.Integer": return ei.getIntField("value");
       case "java.lang.Long":    return ei.getLongField("value");
-      case "java.lang.Float":   return Float.intBitsToFloat(ei.getIntField("value"));
-      case "java.lang.Double":  return Double.longBitsToDouble(ei.getLongField("value"));
+      case "java.lang.Float":   return ei.getFloatField("value");
+      case "java.lang.Double":  return ei.getDoubleField("value");
       case "java.lang.Boolean": return ei.getBooleanField("value");
       case "java.lang.String":  return ei.asString();
       default: return ei;

--- a/src/main/gov/nasa/jpf/vm/JPFStringConcatHelper.java
+++ b/src/main/gov/nasa/jpf/vm/JPFStringConcatHelper.java
@@ -122,9 +122,9 @@ public class JPFStringConcatHelper {
             case "java.lang.Integer": sb.append(ei.getIntField("value")); break;
             case "java.lang.Boolean": sb.append(ei.getBooleanField("value")); break;
             case "java.lang.Float":
-                sb.append(Float.intBitsToFloat(ei.getIntField("value"))); break;
+                sb.append(ei.getFloatField("value")); break;
             case "java.lang.Double":
-                sb.append(Double.longBitsToDouble(ei.getLongField("value"))); break;
+                sb.append(ei.getDoubleField("value")); break;
             case "java.lang.Long":    sb.append(ei.getLongField("value")); break;
             default: sb.append(ei.toString()); break;
         }

--- a/src/tests/java11/StringConcatBoxedFloatDoubleTest.java
+++ b/src/tests/java11/StringConcatBoxedFloatDoubleTest.java
@@ -1,0 +1,67 @@
+package java11;
+
+import gov.nasa.jpf.util.test.TestJPF;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class StringConcatBoxedFloatDoubleTest extends TestJPF {
+
+  @Test
+  public void testBoxedFloatConcat() {
+    if (verifyNoPropertyViolation()) {
+      Float f = 1.5f;
+      String result = "f=" + f;
+      assertEquals("f=1.5", result);
+    }
+  }
+
+  @Test
+  public void testBoxedDoubleConcat() {
+    if (verifyNoPropertyViolation()) {
+      Double d = 3.14;
+      String result = "d=" + d;
+      assertEquals("d=3.14", result);
+    }
+  }
+
+  @Test
+  public void testBoxedFloatAndDoubleConcat() {
+    if (verifyNoPropertyViolation()) {
+      Float f = 1.5f;
+      Double d = 3.14;
+      assertEquals("f=1.5,d=3.14", "f=" + f + ",d=" + d);
+    }
+  }
+
+  @Test
+  public void testBoxedFloatSpecialValues() {
+    if (verifyNoPropertyViolation()) {
+      assertEquals("NaN/-Infinity", "" + Float.NaN + "/" + Float.NEGATIVE_INFINITY);
+    }
+  }
+
+  @Test
+  public void testBoxedDoubleSpecialValues() {
+    if (verifyNoPropertyViolation()) {
+      assertEquals("NaN/-Infinity", "" + Double.NaN + "/" + Double.NEGATIVE_INFINITY);
+    }
+  }
+
+  @Test
+  public void testNullBoxedFloatDoubleConcat() {
+    if (verifyNoPropertyViolation()) {
+      Float f = null;
+      Double d = null;
+      assertEquals("f=null,d=null", "f=" + f + ",d=" + d);
+    }
+  }
+
+  @Test
+  public void testBoxedSpecialValuesConcat() {
+    if (verifyNoPropertyViolation()) {
+      Float f = Float.NaN;
+      Double d = Double.NEGATIVE_INFINITY;
+      assertEquals("NaN/-Infinity", "" + f + "/" + d);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #626 boxed `Float` and `Double` string concatenation by reading wrapper fields using their correct types (`getFloatField()`/`getDoubleField()`) instead of `getIntField()`/`getLongField()`.

## Changes

* Updated `INVOKEDYNAMIC.convertBoxedPrimitive()`
* Updated `JPFStringConcatHelper.handleElementInfo()`
* Added `StringConcatBoxedFloatDoubleTest` as a regression test.

## Testing

* Verified the new test fails before the fix.
* Verified all 7 tests pass after the fix.