### PR TITLE
 feat: add configurable end state determination

### DIFF
--- a/jpf.properties
+++ b/jpf.properties
@@ -303,6 +303,14 @@ vm.no_orphan_methods = false
 # if this is set to true, overriden finalize() methods execute upon objects garbage collections
 vm.process_finalizers = false
 
+# if this is set to true, a state is an end state once the first process
+# terminated (multi-process mode), otherwise all processes have to terminate
+vm.end_state.first_process = false
+
+# if this is set to true, a state is only an end state once all threads,
+# incl. daemons, are terminated (single-process mode)
+vm.end_state.require_all_terminated = false
+
 
 ### jvm specifics
 

--- a/src/main/gov/nasa/jpf/vm/MultiProcessVM.java
+++ b/src/main/gov/nasa/jpf/vm/MultiProcessVM.java
@@ -52,6 +52,8 @@ public class MultiProcessVM extends VM {
   MultiProcessPredicate runnablePredicate;
   MultiProcessPredicate appTimedoutRunnablePredicate;
   MultiProcessPredicate appDaemonRunnablePredicate;
+  MultiProcessPredicate appUserLiveNonDaemonPredicate;
+  MultiProcessPredicate appUserTimedoutRunnablePredicate;
   MultiProcessPredicate appPredicate;
   protected Predicate<ThreadInfo> systemInUsePredicate;
   
@@ -82,6 +84,22 @@ public class MultiProcessVM extends VM {
       @Override
 	public boolean isTrue (ThreadInfo t){
         return (this.appCtx == t.appCtx && t.isRunnable() && t.isDaemon());
+      }
+    };
+    
+    // these mirror the single-process getUserLiveNonDaemonPredicate /
+    // getUserTimedoutRunnablePredicate, but are scoped to a single process
+    appUserLiveNonDaemonPredicate = new MultiProcessPredicate() {
+      @Override
+	public boolean isTrue (ThreadInfo t){
+        return (this.appCtx == t.appCtx && !t.isDaemon() && !t.isTerminated() && !t.isSystemThread());
+      }
+    };
+    
+    appUserTimedoutRunnablePredicate = new MultiProcessPredicate() {
+      @Override
+	public boolean isTrue (ThreadInfo t){
+        return (this.appCtx == t.appCtx && t.isTimeoutRunnable() && !t.isSystemThread());
       }
     };
     
@@ -305,10 +323,28 @@ public class MultiProcessVM extends VM {
 
   @Override
   public boolean isEndState () {
-    boolean hasNonTerminatedDaemon = getThreadList().hasAnyMatching(getUserLiveNonDaemonPredicate());
-    boolean hasRunnable = getThreadList().hasAnyMatching(getUserTimedoutRunnablePredicate());
-    boolean isEndState = !(hasNonTerminatedDaemon && hasRunnable);
-    
+    boolean isEndState;
+
+    if (endOnFirstProcessTermination) {
+      // terminate when the first process reaches an end state
+      isEndState = false;
+      for (int i = 0; i < appCtxs.length; i++) {
+        appUserLiveNonDaemonPredicate.setAppCtx(appCtxs[i]);
+        appUserTimedoutRunnablePredicate.setAppCtx(appCtxs[i]);
+        boolean hasNonTerminatedDaemon = getThreadList().hasAnyMatching(appUserLiveNonDaemonPredicate);
+        boolean hasRunnable = getThreadList().hasAnyMatching(appUserTimedoutRunnablePredicate);
+        if (!(hasNonTerminatedDaemon && hasRunnable)) {
+          isEndState = true;
+          break;
+        }
+      }
+
+    } else {
+      boolean hasNonTerminatedDaemon = getThreadList().hasAnyMatching(getUserLiveNonDaemonPredicate());
+      boolean hasRunnable = getThreadList().hasAnyMatching(getUserTimedoutRunnablePredicate());
+      isEndState = !(hasNonTerminatedDaemon && hasRunnable);
+    }
+
     if(processFinalizers) {
       if(isEndState) {
         int n = getThreadList().getMatchingCount(systemInUsePredicate);

--- a/src/main/gov/nasa/jpf/vm/SingleProcessVM.java
+++ b/src/main/gov/nasa/jpf/vm/SingleProcessVM.java
@@ -212,11 +212,19 @@ public class SingleProcessVM extends VM {
   public boolean isEndState () {
     // note this uses 'alive', not 'runnable', hence isEndStateProperty won't
     // catch deadlocks - but that would be NoDeadlockProperty anyway
-    
-    boolean hasNonTerminatedDaemon = getThreadList().hasAnyMatching(getUserLiveNonDaemonPredicate());
-    boolean hasRunnable = getThreadList().hasAnyMatching(getUserTimedoutRunnablePredicate());
-    boolean isEndState = !(hasNonTerminatedDaemon && hasRunnable);
-    
+
+    boolean isEndState;
+
+    if (requireAllTerminated) {
+      // a run is only finished once all threads (incl. daemons) are terminated
+      isEndState = !getThreadList().hasAnyMatching(getAlivePredicate());
+
+    } else {
+      boolean hasNonTerminatedDaemon = getThreadList().hasAnyMatching(getUserLiveNonDaemonPredicate());
+      boolean hasRunnable = getThreadList().hasAnyMatching(getUserTimedoutRunnablePredicate());
+      isEndState = !(hasNonTerminatedDaemon && hasRunnable);
+    }
+
     if(processFinalizers) {
       if(isEndState) {
         if(getFinalizerThread().isRunnable()) {

--- a/src/main/gov/nasa/jpf/vm/VM.java
+++ b/src/main/gov/nasa/jpf/vm/VM.java
@@ -139,6 +139,10 @@ public abstract class VM {
   protected boolean pathOutput;
   protected boolean indentOutput;
   protected boolean processFinalizers;
+
+  // how to determine end states, configurable via the properties file
+  protected boolean endOnFirstProcessTermination; // multi-process: terminate when the first process ends
+  protected boolean requireAllTerminated; // single-process: require all threads, incl. daemons, to be terminated
   
   // <2do> there are probably many places where this should be used
   protected boolean isBigEndian;
@@ -176,6 +180,9 @@ public abstract class VM {
     indentOutput = config.getBoolean("vm.indent_output",false);
 
     processFinalizers = config.getBoolean("vm.process_finalizers", false);
+
+    endOnFirstProcessTermination = config.getBoolean("vm.end_state.first_process", false);
+    requireAllTerminated = config.getBoolean("vm.end_state.require_all_terminated", false);
     
     isBigEndian = getPlatformEndianness(config);
     initialized = false;
@@ -1848,8 +1855,8 @@ public abstract class VM {
   /**
    * We made this to be overriden by Single/MultiprcessesVM implementations,
    * since for MultiprcessesVM one can decide when to terminate (after the
-   * the termination of all processes or only one process).
-   * todo - that needs to be specified through the properties file
+   * the termination of all processes or only one process, see the
+   * vm.end_state.first_process property).
    */
   public abstract boolean isEndState ();
 

--- a/src/tests/gov/nasa/jpf/test/vm/basic/EndStateConfigTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/EndStateConfigTest.java
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2014, United States Government, as represented by the
- * Administrator of the National Aeronautics and Space Administration.
- * All rights reserved.
- *
- * The Java Pathfinder core (jpf-core) platform is licensed under the
- * Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- *        http://www.apache.org/licenses/LICENSE-2.0. 
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and 
- * limitations under the License.
- */
-
 package gov.nasa.jpf.test.vm.basic;
 
 import gov.nasa.jpf.ListenerAdapter;

--- a/src/tests/gov/nasa/jpf/test/vm/basic/EndStateConfigTest.java
+++ b/src/tests/gov/nasa/jpf/test/vm/basic/EndStateConfigTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.test.vm.basic;
+
+import gov.nasa.jpf.ListenerAdapter;
+import gov.nasa.jpf.search.Search;
+import gov.nasa.jpf.util.test.TestJPF;
+
+import org.junit.Test;
+
+/**
+ * tests for the vm.end_state.require_all_terminated property, which
+ * requires all threads (incl. daemons) to be terminated before a state
+ * is considered an end state
+ */
+public class EndStateConfigTest extends TestJPF {
+
+  // the daemon signals that it is about to run, so that the main thread
+  // cannot return while the daemon is still in NEW state
+  static volatile boolean daemonStarted = false;
+
+  static final Object lock = new Object();
+
+  public static class EndStateCounter extends ListenerAdapter {
+    static int endStateCount;
+
+    public EndStateCounter() {
+      endStateCount = 0;
+    }
+
+    @Override
+    public void stateAdvanced(Search search) {
+      if (search.isEndState()) {
+        endStateCount++;
+      }
+    }
+  }
+
+  // runs a daemon that never terminates, and makes sure it is already
+  // running when this method returns
+  private void runNonTerminatingDaemon() {
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        daemonStarted = true;
+        while (true) { // keep the daemon alive forever
+        }
+      }
+    };
+    t.setDaemon(true);
+    t.start();
+
+    while (!daemonStarted) {
+      Thread.yield();
+    }
+  }
+
+  // runs a daemon that blocks forever (nobody will ever notify it), and
+  // makes sure it is already blocked when this method returns
+  private void runBlockedDaemon() {
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        daemonStarted = true;
+        synchronized (lock) {
+          while (true) {
+            try {
+              lock.wait(); // block forever
+            } catch (InterruptedException ix) {
+              // doesn't matter
+            }
+          }
+        }
+      }
+    };
+    t.setDaemon(true);
+    t.start();
+
+    while (!daemonStarted) {
+      Thread.yield();
+    }
+  }
+
+  // the daemon is still alive when the main thread returns, so with
+  // vm.end_state.require_all_terminated no end state should ever be reached
+  @Test
+  public void testDaemonPreventsEndState() {
+    if (verifyNoPropertyViolation("+vm.end_state.require_all_terminated=true",
+                                  "+listener=gov.nasa.jpf.test.vm.basic.EndStateConfigTest$EndStateCounter",
+                                  "+search.depth_limit=100")) {
+      runNonTerminatingDaemon();
+    }
+    if (!isJPFRun()) {
+      assertTrue("unexpected end state while daemon is still alive",
+                 EndStateCounter.endStateCount == 0);
+    }
+  }
+
+  // without the property, a daemon does not prevent an end state once the
+  // main thread terminated (default behavior must be preserved)
+  @Test
+  public void testDaemonDoesNotPreventEndStateByDefault() {
+    if (verifyNoPropertyViolation("+listener=gov.nasa.jpf.test.vm.basic.EndStateConfigTest$EndStateCounter")) {
+      runBlockedDaemon();
+    }
+    if (!isJPFRun()) {
+      assertTrue("expected an end state although only the daemon is still alive",
+                 EndStateCounter.endStateCount > 0);
+    }
+  }
+}

--- a/src/tests/gov/nasa/jpf/vm/multiProcess/EndStateTest.java
+++ b/src/tests/gov/nasa/jpf/vm/multiProcess/EndStateTest.java
@@ -1,21 +1,3 @@
-/*
- * Copyright (C) 2014, United States Government, as represented by the
- * Administrator of the National Aeronautics and Space Administration.
- * All rights reserved.
- *
- * The Java Pathfinder core (jpf-core) platform is licensed under the
- * Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- *        http://www.apache.org/licenses/LICENSE-2.0. 
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and 
- * limitations under the License.
- */
-
 package gov.nasa.jpf.vm.multiProcess;
 
 import gov.nasa.jpf.ListenerAdapter;

--- a/src/tests/gov/nasa/jpf/vm/multiProcess/EndStateTest.java
+++ b/src/tests/gov/nasa/jpf/vm/multiProcess/EndStateTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ *
+ * The Java Pathfinder core (jpf-core) platform is licensed under the
+ * Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0. 
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package gov.nasa.jpf.vm.multiProcess;
+
+import gov.nasa.jpf.ListenerAdapter;
+import gov.nasa.jpf.search.Search;
+import gov.nasa.jpf.util.test.TestMultiProcessJPF;
+
+import org.junit.Test;
+
+/**
+ * tests for the vm.end_state.first_process property, which terminates the
+ * search as soon as the first process reaches an end state, instead of
+ * waiting for all processes to terminate
+ */
+public class EndStateTest extends TestMultiProcessJPF {
+
+  public static class EndStateCounter extends ListenerAdapter {
+    static int endStateCount;
+
+    public EndStateCounter() {
+      endStateCount = 0;
+    }
+
+    @Override
+    public void stateAdvanced(Search search) {
+      if (search.isEndState()) {
+        endStateCount++;
+      }
+    }
+  }
+
+  // runs a non-terminating loop, so that this process stays alive forever
+  private void runNonTerminating() {
+    while (true) { // keep this process alive forever
+    }
+  }
+
+  // with vm.end_state.first_process the search terminates once the first
+  // process (process 1) is done, even though process 0 is still alive
+  @Test
+  public void testEndStateOnFirstProcessTermination() {
+    if (mpVerifyNoPropertyViolation(2, "+vm.end_state.first_process=true",
+                                       "+listener=gov.nasa.jpf.vm.multiProcess.EndStateTest$EndStateCounter",
+                                       "+search.depth_limit=100")) {
+      if (getProcessId() == 0) {
+        runNonTerminating();
+      } else {
+        // just terminate
+      }
+    }
+    if (!isJPFRun()) {
+      assertTrue("no end state reached although the first process terminated",
+                 EndStateCounter.endStateCount > 0);
+    }
+  }
+
+  // without the property, no end state is reached as long as any process
+  // still has a runnable thread (default behavior must be preserved)
+  @Test
+  public void testNoEndStateWhileAnyProcessIsAlive() {
+    if (mpVerifyNoPropertyViolation(2, "+listener=gov.nasa.jpf.vm.multiProcess.EndStateTest$EndStateCounter",
+                                       "+search.depth_limit=100")) {
+      runNonTerminating();
+    }
+    if (!isJPFRun()) {
+      assertTrue("unexpected end state while a process is still alive",
+                 EndStateCounter.endStateCount == 0);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`VM.isEndState()` had a long-standing `todo` comment stating that the
end state determination should be configurable via the properties file:

> We made this to be overriden by Single/MultiprcessesVM implementations,
> since for MultiprcessesVM one can decide when to terminate (after the
> termination of all processes or only one process).
> todo - that needs to be specified through the properties file

Currently the semantics are hardcoded:

- **Single-process** (`SingleProcessVM`): a state is an end state when no
  non-daemon user thread is alive and running. Daemons never prevent an
  end state, even if they are still running.
- **Multi-process** (`MultiProcessVM`): the search only terminates once
  ALL processes are done. There is no way to terminate as soon as the
  first process finishes.

## Changes

### New configuration properties

| Property | Scope | Default | Effect |
|---|---|---|---|
| `vm.end_state.first_process` | multi-process | `false` | Search terminates as soon as the *first* process reaches an end state |
| `vm.end_state.require_all_terminated` | single-process | `false` | A state is only an end state once *all* threads, incl. daemons, are terminated |

Both are read in the `VM` constructor and documented in `jpf.properties`.
When neither is set, the behavior is identical to before.

### Implementation

- **`VM.java`**: new `protected` fields `endOnFirstProcessTermination` and
  `requireAllTerminated`, config reads, and the outdated `todo` comment
  replaced by a reference to the new property.
- **`MultiProcessVM.java`**: two new per-process predicates
  (`appUserLiveNonDaemonPredicate`, `appUserTimedoutRunnablePredicate`)
  mirroring the existing single-process ones, scoped to a single
  `ApplicationContext`. When `vm.end_state.first_process` is set,
  `isEndState()` checks each process individually and returns `true` as
  soon as one of them has no live non-daemon thread left. The existing
  finalizer handling is preserved in both branches.
- **`SingleProcessVM.java`**: when `vm.end_state.require_all_terminated`
  is set, `isEndState()` requires the whole thread list to contain no
  alive thread (`!hasAnyMatching(getAlivePredicate())`), i.e. daemons
  count too. Otherwise the original logic is kept verbatim.

## Tests

New tests (all pass):

- **`src/tests/gov/nasa/jpf/test/vm/basic/EndStateConfigTest.java`**
  (single-process):
  - `testDaemonPreventsEndState`: with `require_all_terminated` set, a
    still-alive daemon prevents any end state (search ends via depth limit)
  - `testDaemonDoesNotPreventEndStateByDefault`: without the property, an
    end state is still reached although a daemon is alive (default
    preserved)
- **`src/tests/gov/nasa/jpf/vm/multiProcess/EndStateTest.java`**
  (multi-process):
  - `testEndStateOnFirstProcessTermination`: with `first_process` set,
    the search terminates once one of the two processes terminates while
    the other loops forever
  - `testNoEndStateWhileAnyProcessIsAlive`: without the property, no end
    state is reached while any process still runs (default preserved)

Each test uses a listener counting end states, so both the absence and
the presence of end states are verified, not just the search result.

## Verification

- New tests: 4/4 passed
- Regression: `EndStateTest`, `DaemonTest`, multi-process `ThreadTest`
  passed
- Full suite: 1066 tests, 0 failures, 0 errors