### PR TITLE
feat: add optional per-test classloader isolation

### DIFF
--- a/src/main/gov/nasa/jpf/JPFClassLoader.java
+++ b/src/main/gov/nasa/jpf/JPFClassLoader.java
@@ -81,4 +81,12 @@ public class JPFClassLoader extends URLClassLoader {
   public void setNativeLibs (String[] libs){
     nativeLibs = libs;
   }
+  
+  public URL[] getURLs() {
+    return super.getURLs();
+  }
+  
+  public String[] getNativeLibs() {
+    return nativeLibs;
+  }
 }

--- a/src/main/gov/nasa/jpf/tool/RunTest.java
+++ b/src/main/gov/nasa/jpf/tool/RunTest.java
@@ -159,11 +159,12 @@ public class RunTest extends Run {
       warning("incompatible " + TESTJPF_CLS + " version, quiet mode will not work");
     }
     
-    // <2do> refactor - each test class should be (optionally) loaded through a new ClassLoader instance
-    // to make sure tests don't have static field carry-over
+    // Check if per-test ClassLoader isolation is enabled
+    boolean isolateClassLoaders = config.getBoolean("jpf.test.isolated_classloader", false);
     
-    List<Class<?>> testClasses = getTestClasses(cl, testJpfCls, testPathElements, testClsName);
-    if (testClasses.isEmpty()){
+    // Get test class names (not loaded classes) to support per-test classloader isolation
+    List<String> testClassNames = getTestClassNames(cl, testJpfCls, testPathElements, testClsName);
+    if (testClassNames.isEmpty()){
       System.out.println("no test classes found");
       return;
     }
@@ -171,8 +172,17 @@ public class RunTest extends Run {
     int nTested = 0;
     int nPass = 0;
     
-    for (Class<?> testCls : testClasses){
+    for (String className : testClassNames){
       nTested++;
+      
+      // Create isolated ClassLoader per test class if enabled
+      JPFClassLoader testCl = isolateClassLoaders ? createIsolatedTestClassLoader(cl, testPathElements) : cl;
+      
+      Class<?> testCls = loadTestClass(testCl, testJpfCls, className);
+      if (testCls == null) {
+        error("class did not resolve or no TestJPF derived class: " + className);
+        continue;
+      }
       
       try {
         try {
@@ -233,6 +243,43 @@ public class RunTest extends Run {
   
   static boolean hasWildcard (String pattern){
     return (pattern.indexOf('*') >= 0);
+  }
+  
+  // Get test class names (not loaded classes) - used for per-test classloader isolation
+  static List<String> getTestClassNames (JPFClassLoader cl, Class<?> testJpfCls, String[] testPathElements, String testClsPattern ){
+    List<String> testClassNames = new ArrayList<String>();
+    
+    if (testClsPattern.startsWith(".")){
+      testClsPattern = "gov.nasa.jpf" + testClsPattern;
+    }
+    
+    if (!hasWildcard(testClsPattern)){ // explicit class name
+      Class<?> testCls = loadTestClass( cl, testJpfCls, testClsPattern);
+      if (testCls == null){ // error if this was an explicit classname
+        error ("specified class name not found or no TestJPF derived class: " + testClsPattern);  
+      } else {
+        testClassNames.add(testClsPattern);
+      }
+      
+    } else { // wildcard pattern - find all matching class files
+      List<String> classFileList = getClassFileList( testPathElements, testClsPattern);
+      
+      for (String candidate : classFileList){        
+        Class<?> testCls = loadTestClass( cl, testJpfCls, candidate);
+        if (testCls != null){
+          testClassNames.add(candidate);
+        }
+      }
+    }
+    
+    return testClassNames;
+  }
+  
+  // Create an isolated child ClassLoader for a single test class
+  static JPFClassLoader createIsolatedTestClassLoader(JPFClassLoader parent, String[] testPathElements){
+    JPFClassLoader isolated = new JPFClassLoader(parent.getURLs(), parent.getNativeLibs(), parent);
+    addTestClassPath(isolated, testPathElements);
+    return isolated;
   }
   
   static List<Class<?>> getTestClasses (JPFClassLoader cl, Class<?> testJpfCls, String[] testPathElements, String testClsPattern ){

--- a/src/tests/gov/nasa/jpf/JPFClassLoaderTest.java
+++ b/src/tests/gov/nasa/jpf/JPFClassLoaderTest.java
@@ -1,0 +1,103 @@
+package gov.nasa.jpf;
+
+import gov.nasa.jpf.util.test.TestJPF;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+/**
+ * Tests for JPFClassLoader accessor methods added for per-test
+ * ClassLoader isolation (getURLs, getNativeLibs).
+ */
+public class JPFClassLoaderTest extends TestJPF {
+
+  @Test
+  public void testGetURLsReturnsConstructorURLs() throws Exception {
+    URL[] urls = { new URL("file:///tmp/test1.jar"), new URL("file:///tmp/test2.jar") };
+    JPFClassLoader cl = new JPFClassLoader(urls);
+
+    URL[] result = cl.getURLs();
+    assertNotNull(result);
+    assertEquals(urls.length, result.length);
+    for (int i = 0; i < urls.length; i++) {
+      assertEquals(urls[i], result[i]);
+    }
+  }
+
+  @Test
+  public void testGetURLsEmptyByDefault() {
+    JPFClassLoader cl = new JPFClassLoader(new URL[0]);
+    URL[] result = cl.getURLs();
+    assertNotNull(result);
+    assertEquals(0, result.length);
+  }
+
+  @Test
+  public void testGetNativeLibsFromConstructor() {
+    String[] nativeLibs = { "/usr/lib/libfoo.so", "/usr/lib/libbar.so" };
+    JPFClassLoader cl = new JPFClassLoader(new URL[0], nativeLibs, null);
+
+    String[] result = cl.getNativeLibs();
+    assertNotNull(result);
+    assertEquals(nativeLibs.length, result.length);
+    for (int i = 0; i < nativeLibs.length; i++) {
+      assertEquals(nativeLibs[i], result[i]);
+    }
+  }
+
+  @Test
+  public void testGetNativeLibsNullWhenNotSet() {
+    JPFClassLoader cl = new JPFClassLoader(new URL[0]);
+    assertNull(cl.getNativeLibs());
+  }
+
+  @Test
+  public void testSetNativeLibs() {
+    JPFClassLoader cl = new JPFClassLoader(new URL[0]);
+    assertNull(cl.getNativeLibs());
+
+    String[] nativeLibs = { "/usr/lib/libtest.so" };
+    cl.setNativeLibs(nativeLibs);
+
+    String[] result = cl.getNativeLibs();
+    assertNotNull(result);
+    assertEquals(1, result.length);
+    assertEquals("/usr/lib/libtest.so", result[0]);
+  }
+
+  @Test
+  public void testChildClassLoaderDelegation() throws Exception {
+    URL[] urls = { new URL("file:///tmp/test.jar") };
+    String[] nativeLibs = { "/usr/lib/libfoo.so" };
+    JPFClassLoader parent = new JPFClassLoader(urls, nativeLibs, null);
+
+    JPFClassLoader child = new JPFClassLoader(parent.getURLs(), parent.getNativeLibs(), parent);
+
+    assertNotNull(child.getParent());
+    assertEquals(parent, child.getParent());
+
+    URL[] childUrls = child.getURLs();
+    assertNotNull(childUrls);
+    assertEquals(1, childUrls.length);
+    assertEquals(urls[0], childUrls[0]);
+
+    String[] childLibs = child.getNativeLibs();
+    assertNotNull(childLibs);
+    assertEquals(1, childLibs.length);
+    assertEquals(nativeLibs[0], childLibs[0]);
+  }
+
+  @Test
+  public void testChildClassLoaderIndependentURLs() throws Exception {
+    URL[] parentUrls = { new URL("file:///tmp/parent.jar") };
+    JPFClassLoader parent = new JPFClassLoader(parentUrls, null, null);
+
+    JPFClassLoader child = new JPFClassLoader(parent.getURLs(), null, parent);
+
+    child.addURL(new URL("file:///tmp/child.jar"));
+
+    assertEquals(1, parent.getURLs().length);
+    assertEquals(2, child.getURLs().length);
+  }
+}

--- a/src/tests/gov/nasa/jpf/tool/RunTestIsolationTest.java
+++ b/src/tests/gov/nasa/jpf/tool/RunTestIsolationTest.java
@@ -1,0 +1,100 @@
+package gov.nasa.jpf.tool;
+
+import gov.nasa.jpf.Config;
+import gov.nasa.jpf.JPFClassLoader;
+import gov.nasa.jpf.util.test.TestJPF;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+/**
+ * Tests for RunTest's per-test ClassLoader isolation feature.
+ * These tests run on the host JVM (not inside JPF) since they test
+ * the host-side test runner infrastructure.
+ */
+public class RunTestIsolationTest extends TestJPF {
+
+  @Test
+  public void testCreateIsolatedClassLoaderCreatesChild() throws Exception {
+    URL[] urls = { new URL("file:///tmp/test.jar") };
+    String[] nativeLibs = { "/usr/lib/libfoo.so" };
+    JPFClassLoader parent = new JPFClassLoader(urls, nativeLibs, null);
+
+    String[] testPathElements = { "src/tests" };
+    JPFClassLoader isolated = RunTest.createIsolatedTestClassLoader(parent, testPathElements);
+
+    assertNotNull(isolated);
+    assertTrue("Isolated CL should be different from parent", parent != isolated);
+    assertEquals(parent, isolated.getParent());
+  }
+
+  @Test
+  public void testIsolatedClassLoaderInheritsParentURLs() throws Exception {
+    URL[] parentUrls = { new URL("file:///tmp/parent.jar") };
+    JPFClassLoader parent = new JPFClassLoader(parentUrls, null, null);
+
+    String[] testPathElements = {};
+    JPFClassLoader isolated = RunTest.createIsolatedTestClassLoader(parent, testPathElements);
+
+    URL[] isolatedUrls = isolated.getURLs();
+    assertNotNull(isolatedUrls);
+    assertTrue(isolatedUrls.length >= parentUrls.length);
+    for (URL url : parentUrls) {
+      boolean found = false;
+      for (URL iUrl : isolatedUrls) {
+        if (url.equals(iUrl)) {
+          found = true;
+          break;
+        }
+      }
+      assertTrue("Parent URL should be inherited: " + url, found);
+    }
+  }
+
+  @Test
+  public void testIsolatedClassLoaderHasSeparateNamespace() throws Exception {
+    URL[] urls = { new URL("file:///tmp/test.jar") };
+    JPFClassLoader parent = new JPFClassLoader(urls, null, null);
+
+    String[] testPathElements = {};
+    JPFClassLoader isolated1 = RunTest.createIsolatedTestClassLoader(parent, testPathElements);
+    JPFClassLoader isolated2 = RunTest.createIsolatedTestClassLoader(parent, testPathElements);
+
+    assertTrue("Two isolated CLs should be different instances", isolated1 != isolated2);
+    assertEquals(parent, isolated1.getParent());
+    assertEquals(parent, isolated2.getParent());
+  }
+
+  @Test
+  public void testConfigIsolatedClassloaderDefault() {
+    Config config = new Config(new String[0]);
+    boolean isolated = config.getBoolean("jpf.test.isolated_classloader", false);
+    assertFalse("Isolation should be disabled by default", isolated);
+  }
+
+  @Test
+  public void testConfigIsolatedClassloaderEnabled() {
+    String[] args = { "+jpf.test.isolated_classloader=true" };
+    Config config = new Config(args);
+    boolean isolated = config.getBoolean("jpf.test.isolated_classloader", false);
+    assertTrue("Isolation should be enabled", isolated);
+  }
+
+  @Test
+  public void testIsolatedClassLoaderSharesNativeLibs() throws Exception {
+    URL[] urls = { new URL("file:///tmp/test.jar") };
+    String[] nativeLibs = { "/usr/lib/libfoo.so", "/usr/lib/libbar.so" };
+    JPFClassLoader parent = new JPFClassLoader(urls, nativeLibs, null);
+
+    String[] testPathElements = {};
+    JPFClassLoader isolated = RunTest.createIsolatedTestClassLoader(parent, testPathElements);
+
+    String[] isolatedLibs = isolated.getNativeLibs();
+    assertNotNull(isolatedLibs);
+    assertEquals(nativeLibs.length, isolatedLibs.length);
+    for (int i = 0; i < nativeLibs.length; i++) {
+      assertEquals(nativeLibs[i], isolatedLibs[i]);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements the `<2do>` at RunTest.java:162 to add optional per-test ClassLoader isolation. This feature allows each test class to be loaded through its own isolated child ClassLoader, preventing static field carry-over between test classes.

## Problem
Currently, all test classes are loaded through a single shared `JPFClassLoader`. This means static fields persist between test runs, causing test pollution and potentially flaky tests when:
- Test class A sets a static field
- Test class B reads the same static field (now has value from A)
- Test order affects test results

## Solution
Added optional per-test ClassLoader isolation via config option `jpf.test.isolated_classloader`. When enabled, each test class gets its own isolated child ClassLoader that:
- Delegates to parent for shared classes (TestJPF, JPF core)
- Has its own namespace for test classes
- Shares the same test classpath (`test_classpath` from config)
- Prevents static field carry-over between test classes

## Changes

### RunTest.java
- Added config option `jpf.test.isolated_classloader` (default: `false`)
- Added `getTestClassNames()` - returns class names instead of loaded classes to support per-test classloader isolation
- Added `createIsolatedTestClassLoader()` - creates child ClassLoader with same test classpath
- Modified main loop to create isolated ClassLoader per test class when enabled
- Removed the `<2do>` comment at line 162 (implemented)

### JPFClassLoader.java
- Added `getURLs()` - returns classpath URLs (delegates to superclass)
- Added `getNativeLibs()` - returns native library paths
- These enable creating child ClassLoaders with identical configuration

## Usage

### Command Line
```bash
# Run with isolation enabled
./bin/test +jpf.test.isolated_classloader=true <test-class>

# Run multiple tests with isolation
./bin/test +jpf.test.isolated_classloader=true gov.nasa.jpf.test.java.lang.StringTest gov.nasa.jpf.test.java.lang.ClassLoaderTest
```

### Configuration File (jpf.properties)
```properties
jpf.test.isolated_classloader=true
```

## Testing
All existing tests pass with isolation **disabled** (default):
```bash
./bin/test gov.nasa.jpf.test.java.lang.StringTest
./bin/test gov.nasa.jpf.test.java.lang.ClassLoaderTest
./bin/test gov.nasa.jpf.test.vm.basic.FieldTest
./bin/test gov.nasa.jpf.test.java.lang.reflect.FieldTest
```

All existing tests pass with isolation **enabled**:
```bash
./bin/test +jpf.test.isolated_classloader=true gov.nasa.jpf.test.java.lang.StringTest
./bin/test +jpf.test.isolated_classloader=true gov.nasa.jpf.test.java.lang.ClassLoaderTest
./bin/test +jpf.test.isolated_classloader=true gov.nasa.jpf.test.vm.basic.FieldTest
./bin/test +jpf.test.isolated_classloader=true gov.nasa.jpf.test.java.lang.reflect.FieldTest
```

## Implementation Details

### How Isolation Works
1. Parent `JPFClassLoader` (`cl`) is created with full classpath
2. For each test class, if isolation enabled:
   - Create child `JPFClassLoader` with `new JPFClassLoader(parent.getURLs(), parent.getNativeLibs(), parent)`
   - Add test classpath via `addTestClassPath()`
   - Load test class through isolated ClassLoader
3. Child ClassLoader delegates to parent for shared classes (TestJPF, JPF core, JDK classes)
4. Test classes are loaded in child's namespace → static fields isolated

### Backward Compatibility
- Isolation **disabled by default** (`jpf.test.isolated_classloader=false`)
- No behavior change for existing users
- Opt-in feature via config option

## Files Changed
- `src/main/gov/nasa/jpf/tool/RunTest.java` - Main implementation
- `src/main/gov/nasa/jpf/JPFClassLoader.java` - Added accessor methods

## Related
- Fixes `<2do>` at RunTest.java:162: "refactor - each test class should be (optionally) loaded through a new ClassLoader instance to make sure tests don't have static field carry-over"

## Future Considerations
- Could add `@IsolatedClassLoader` annotation for per-class opt-in
- Could add test listener to auto-detect static field pollution
- Consider performance impact for large test suites (minimal - child ClassLoaders share parent)

## Checklist
- [x] All existing tests pass (isolation disabled)
- [x] All existing tests pass (isolation enabled)
- [x] Backward compatible (disabled by default)
- [x] Removed `<2do>` comment
- [x] Config option documented
- [x] Child ClassLoader properly delegates to parent