### PR TITLE
Fix Class.getResourceAsStream() to load from SUT classpath

### DIFF
--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -113,7 +113,17 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   private native byte[] getByteArrayFromResourceStream(String name);
 
   public InputStream getResourceAsStream (String name) {
-    byte[] byteArray = getByteArrayFromResourceStream(name);
+    String resolvedName = getResolvedName(name);
+    String moduleName = getModuleName();
+
+    if (moduleName != null) {
+      if(isJPFClass())
+        resolvedName = "modules/" + moduleName + "/" + resolvedName;
+      else
+        resolvedName = moduleName + "/" + resolvedName;
+    }
+
+    byte[] byteArray = getByteArrayFromResourceStream(resolvedName);
     if (byteArray == null) return null;
     return new ByteArrayInputStream(byteArray);
   }

--- a/src/classes/modules/java.base/java/lang/Class.java
+++ b/src/classes/modules/java.base/java/lang/Class.java
@@ -113,6 +113,10 @@ public final class Class<T> implements Serializable, GenericDeclaration, Type, A
   private native byte[] getByteArrayFromResourceStream(String name);
 
   public InputStream getResourceAsStream (String name) {
+    if (name == null) {
+      throw new NullPointerException("name");
+    }
+
     String resolvedName = getResolvedName(name);
     String moduleName = getModuleName();
 

--- a/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
+++ b/src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java
@@ -715,32 +715,44 @@ public class JPF_java_lang_Class extends NativePeer {
 
 
   /**
-   * <2do> needs to load from the classfile location, NOT the MJIEnv (native) class
+   * Loads a resource from the classpath of the class this native method is
+   * invoked on (i.e. the system under test), NOT from the location of this
+   * peer class on the host VM.
+   *
+   * The name is expected to be already resolved into its absolute,
+   * slash-separated form by java.lang.Class.getResourceAsStream() (via
+   * getResolvedName()), i.e. it does not have a leading '/' and relative
+   * names are prefixed with the package of the requesting class.
+   *
+   * Returns the resource content as a byte array, or null if the resource
+   * cannot be found in the classpath of the requesting class.
    *
    * @author Sebastian Gfeller (sebastian.gfeller@gmail.com)
    * @author Tihomir Gvero (tihomir.gvero@gmail.com)
    */
   @MJI
   public int getByteArrayFromResourceStream__Ljava_lang_String_2___3B(MJIEnv env, int clsRef, int nameRef) {
+    ClassInfo ci = env.getReferredClassInfo(clsRef);
     String name = env.getStringObject(nameRef);
 
-    // <2do> this is not loading from the classfile location! fix it
-    InputStream is = env.getClass().getResourceAsStream(name);
-    if (is == null){
+    String url = ci.getClassLoaderInfo().findResource(name);
+    if (url == null){
       return MJIEnv.NULL;
     }
-    // We assume that the entire input stream can be read at the moment,
-    // although this could break.
-    byte[] content = null;
+
     try {
-      content = new byte[is.available()];
-      is.read(content);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+      InputStream is = new java.net.URL(url).openStream();
+      byte[] content;
+      try {
+        content = is.readAllBytes();
+      } finally {
+        is.close();
+      }
+      return env.newByteArray(content);
+
+    } catch (IOException x) {
+      return MJIEnv.NULL;
     }
-    // Now if everything worked, the content should be in the byte buffer.
-    // We put this buffer into the JPF VM.
-    return env.newByteArray(content);
   }
 
   @MJI

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -693,46 +693,169 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
     }
   }
 
+  //--- getResourceAsStream() regression tests ---
+  // resources have to be loaded from the SUT classpath, i.e. the location
+  // of the class they are requested on, not from the native peer location
+
+  static final String RESOURCE_FIXTURE_NAME = "ClassTestFixture.txt";
+  static final String RESOURCE_FIXTURE_DIR = "gov/nasa/jpf/test/java/lang";
+  // NOTE - deliberately pure ASCII: comparing non-ASCII content would require
+  // charset decoding under JPF, which is a separate known limitation
+  // (orphan java.lang.StringCoding native peers)
+  static final String RESOURCE_FIXTURE_CONTENT =
+          "Hello from SUT classpath!\nSecond line\n";
+
+  /**
+   * create the resource fixtures next to the compiled test class so that
+   * they are on the SUT classpath when JPF verifies this test class
+   */
+  private static void ensureResourceFixtures () {
+    try {
+      File clsFile = new File(ClassTest.class.getResource("ClassTest.class").toURI());
+      File dir = clsFile.getParentFile();
+
+      File fixture = new File(dir, RESOURCE_FIXTURE_NAME);
+      Files.write(fixture.toPath(),
+                  RESOURCE_FIXTURE_CONTENT.getBytes(StandardCharsets.UTF_8));
+      fixture.deleteOnExit();
+
+      File subDir = new File(dir, "resource_subdir");
+      Files.createDirectories(subDir.toPath());
+      File subFixture = new File(subDir, RESOURCE_FIXTURE_NAME);
+      Files.write(subFixture.toPath(), "nested fixture".getBytes(StandardCharsets.UTF_8));
+      subFixture.deleteOnExit();
+    } catch (IOException x){
+      throw new RuntimeException("failed to create resource fixtures", x);
+    } catch (java.net.URISyntaxException x){
+      throw new RuntimeException("failed to locate compiled ClassTest.class", x);
+    }
+  }
+
   @Test
-  public void getResourceAsStreamTest() {
+  public void getResourceAsStreamRelativeTest() {
     if (!isJPFRun()){
-      // create the fixture next to the compiled test class so that it is on
-      // the SUT classpath when JPF verifies this very test class
-      try {
-        File clsFile = new File(ClassTest.class.getResource("ClassTest.class").toURI());
-        File fixture = new File(clsFile.getParentFile(), "ClassTestFixture.txt");
-        Files.write(fixture.toPath(),
-                    "Hello from SUT classpath!".getBytes(StandardCharsets.UTF_8));
-        fixture.deleteOnExit();
-      } catch (IOException x){
-        throw new RuntimeException("failed to create ClassTestFixture.txt", x);
-      } catch (java.net.URISyntaxException x){
-        throw new RuntimeException("failed to locate compiled ClassTest.class", x);
-      }
+      ensureResourceFixtures();
+    }
+
+    if (verifyNoPropertyViolation()){
+      // relative lookup resolves against the package of the requesting class
+      InputStream is = ClassTest.class.getResourceAsStream(RESOURCE_FIXTURE_NAME);
+      assertNotNull("relative lookup should find the fixture", is);
+      assertStreamContent(is, RESOURCE_FIXTURE_CONTENT);
+    }
+  }
+
+  @Test
+  public void getResourceAsStreamAbsoluteTest() {
+    if (!isJPFRun()){
+      ensureResourceFixtures();
+    }
+
+    if (verifyNoPropertyViolation()){
+      InputStream is = ClassTest.class.getResourceAsStream(
+              "/" + RESOURCE_FIXTURE_DIR + "/" + RESOURCE_FIXTURE_NAME);
+      assertNotNull("absolute lookup should find the fixture", is);
+      assertStreamContent(is, RESOURCE_FIXTURE_CONTENT);
+    }
+  }
+
+  @Test
+  public void getResourceAsStreamNestedRelativeTest() {
+    if (!isJPFRun()){
+      ensureResourceFixtures();
+    }
+
+    if (verifyNoPropertyViolation()){
+      InputStream is = ClassTest.class.getResourceAsStream(
+              "resource_subdir/" + RESOURCE_FIXTURE_NAME);
+      assertNotNull("nested relative lookup should find the fixture", is);
+      assertStreamContent(is, "nested fixture");
+    }
+  }
+
+  @Test
+  public void getResourceAsStreamNotFoundTest() {
+    if (!isJPFRun()){
+      ensureResourceFixtures();
     }
 
     if (verifyNoPropertyViolation()){
       Class<?> c = ClassTest.class;
 
-      // relative lookup - resolves against the package of the requesting class
-      InputStream is = c.getResourceAsStream("ClassTestFixture.txt");
-      assertNotNull("relative getResourceAsStream() failed", is);
-      String content = readContent(is);
-      assertTrue("wrong content: " + content,
-                 content.contains("Hello from SUT classpath!"));
+      // non-existing absolute and relative names
+      assertNull(c.getResourceAsStream(
+              "/" + RESOURCE_FIXTURE_DIR + "/no_such_resource.xyz"));
+      assertNull(c.getResourceAsStream("no_such_resource.xyz"));
 
-      // absolute lookup
-      InputStream is2 = c.getResourceAsStream(
-          "/gov/nasa/jpf/test/java/lang/ClassTestFixture.txt");
-      assertNotNull("absolute getResourceAsStream() failed", is2);
-      assertEquals(content, readContent(is2));
+      // scoping - requesting from another class resolves against ITS package
+      assertNull(System.class.getResourceAsStream(RESOURCE_FIXTURE_NAME));
 
-      // non-existing resource
-      assertNull(c.getResourceAsStream("/gov/nasa/jpf/test/java/lang/no_such_resource.xyz"));
+      // a fully qualified path without leading '/' is still package-relative,
+      // i.e. must not find the fixture in its real location
+      assertNull(c.getResourceAsStream(RESOURCE_FIXTURE_DIR + "/" + RESOURCE_FIXTURE_NAME));
     }
   }
 
-  private static String readContent (InputStream is) {
+  @Test
+  public void getResourceAsStreamFromJarTest() {
+    if (verifyNoPropertyViolation()){
+      // asm-9.5.jar is part of jpf-core.test_classpath, hence on the SUT
+      // classpath; this exercises lookup inside a jar classpath entry.
+      // Every Java classfile starts with the magic bytes 0xCAFEBABE.
+      InputStream is = ClassTest.class.getResourceAsStream(
+              "/org/objectweb/asm/AnnotationVisitor.class");
+      assertNotNull("jar entry lookup should find AnnotationVisitor.class", is);
+
+      try {
+        int b0 = is.read();
+        int b1 = is.read();
+        int b2 = is.read();
+        int b3 = is.read();
+        is.close();
+
+        assertEquals(0xCA, b0);
+        assertEquals(0xFE, b1);
+        assertEquals(0xBA, b2);
+        assertEquals(0xBE, b3);
+      } catch (IOException x){
+        throw new RuntimeException(x);
+      }
+    }
+  }
+
+  @Test
+  public void getResourceAsStreamConsistencyTest() {
+    if (!isJPFRun()){
+      ensureResourceFixtures();
+    }
+
+    if (verifyNoPropertyViolation()){
+      Class<?> c = ClassTest.class;
+      String absName = "/" + RESOURCE_FIXTURE_DIR + "/" + RESOURCE_FIXTURE_NAME;
+      String missingName = "/" + RESOURCE_FIXTURE_DIR + "/no_such_resource.xyz";
+
+      // getResource() and getResourceAsStream() have to agree on existence
+      assertNotNull(c.getResource(absName));
+      assertNotNull(c.getResourceAsStream(absName));
+
+      assertNull(c.getResource(missingName));
+      assertNull(c.getResourceAsStream(missingName));
+    }
+  }
+
+  @Test
+  public void getResourceAsStreamNullNameTest() {
+    if (verifyUnhandledException("java.lang.NullPointerException")){
+      // same behavior as on a standard JVM
+      ClassTest.class.getResourceAsStream(null);
+    }
+  }
+
+  /**
+   * reads the stream content and compares it byte-wise against the expected
+   * (pure ASCII) content, avoiding any charset decoding under JPF
+   */
+  private static void assertStreamContent (InputStream is, String expected) {
     try {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       byte[] buf = new byte[256];
@@ -740,7 +863,14 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
         bos.write(buf, 0, n);
       }
       is.close();
-      return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+
+      byte[] actual = bos.toByteArray();
+      assertEquals("content length mismatch", expected.length(), actual.length);
+      for (int i = 0; i < actual.length; i++){
+        if ((byte) expected.charAt(i) != actual[i]){
+          fail("content mismatch at byte index " + i);
+        }
+      }
     } catch (IOException x){
       throw new RuntimeException(x);
     }

--- a/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
+++ b/src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java
@@ -39,11 +39,17 @@ import gov.nasa.jpf.util.test.TestJPF;
 import gov.nasa.jpf.vm.Verify;
 import gov.nasa.jpf.test.test_classes.class_test.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 import org.junit.Test;
@@ -685,7 +691,60 @@ public class ClassTest extends TestJPF implements Cloneable, Serializable {
       assertEquals(c.getResource("Class.class"),c.getResource("/java/lang/Class.class"));
       assertNull(c.getResource("not_existing_resources"));
     }
-  }  
+  }
+
+  @Test
+  public void getResourceAsStreamTest() {
+    if (!isJPFRun()){
+      // create the fixture next to the compiled test class so that it is on
+      // the SUT classpath when JPF verifies this very test class
+      try {
+        File clsFile = new File(ClassTest.class.getResource("ClassTest.class").toURI());
+        File fixture = new File(clsFile.getParentFile(), "ClassTestFixture.txt");
+        Files.write(fixture.toPath(),
+                    "Hello from SUT classpath!".getBytes(StandardCharsets.UTF_8));
+        fixture.deleteOnExit();
+      } catch (IOException x){
+        throw new RuntimeException("failed to create ClassTestFixture.txt", x);
+      } catch (java.net.URISyntaxException x){
+        throw new RuntimeException("failed to locate compiled ClassTest.class", x);
+      }
+    }
+
+    if (verifyNoPropertyViolation()){
+      Class<?> c = ClassTest.class;
+
+      // relative lookup - resolves against the package of the requesting class
+      InputStream is = c.getResourceAsStream("ClassTestFixture.txt");
+      assertNotNull("relative getResourceAsStream() failed", is);
+      String content = readContent(is);
+      assertTrue("wrong content: " + content,
+                 content.contains("Hello from SUT classpath!"));
+
+      // absolute lookup
+      InputStream is2 = c.getResourceAsStream(
+          "/gov/nasa/jpf/test/java/lang/ClassTestFixture.txt");
+      assertNotNull("absolute getResourceAsStream() failed", is2);
+      assertEquals(content, readContent(is2));
+
+      // non-existing resource
+      assertNull(c.getResourceAsStream("/gov/nasa/jpf/test/java/lang/no_such_resource.xyz"));
+    }
+  }
+
+  private static String readContent (InputStream is) {
+    try {
+      ByteArrayOutputStream bos = new ByteArrayOutputStream();
+      byte[] buf = new byte[256];
+      for (int n; (n = is.read(buf)) > 0; ){
+        bos.write(buf, 0, n);
+      }
+      is.close();
+      return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+    } catch (IOException x){
+      throw new RuntimeException(x);
+    }
+  }
 }
 
 class TestNewInstance {


### PR DESCRIPTION
# Fix `Class.getResourceAsStream()` to load from SUT classpath instead of peer location

## Summary

Under JPF, `Class.getResourceAsStream(name)` always returned `null` for resources
that live next to the classes of the system under test (SUT) — while the exact
same program works on a standard JVM. The root cause was that the native peer
resolved resources against **JPF's own location** instead of the requesting
class's classpath. This PR fixes resource lookup to use the SUT's classpath and
adds a comprehensive regression test suite covering all lookup variants.

This also removes both long-standing `<2do>` markers at this site:

```
src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java:
  * <2do> needs to load from the classfile location, NOT the MJIEnv (native) class
  // <2do> this is not loading from the classfile location! fix it
```

---

## Problem

### Reproduction

A minimal SUT with a resource file on its classpath:

```java
public class Demo {
    public static void main(String[] args) throws Exception {
        InputStream is = Demo.class.getResourceAsStream("demo_resource.txt");
        System.out.println(is == null ? "null" : "found");
    }
}
```

| Execution            | Result |
|----------------------|--------|
| `java -cp . Demo`    | `found` — content readable |
| `jpf +classpath=. Demo` | **`null`** → downstream NPE |

Any application reading configuration files, templates or data files shipped
next to its classes fails under JPF.

### Root cause

`java.lang.Class.getResourceAsStream(String)` is a modeled method backed by a
native helper. The peer resolved the resource via the **peer class itself**
running on the host VM:

```java
// src/peers/gov/nasa/jpf/vm/JPF_java_lang_Class.java  (before)
@MJI
public int getByteArrayFromResourceStream__Ljava_lang_String_2___3B (
        MJIEnv env, int clsRef, int nameRef) {
  String name = env.getStringObject(nameRef);

  // <2do> this is not loading from the classfile location! fix it
  InputStream is = env.getClass().getResourceAsStream(name);   // <-- BUG
  ...
}
```

`env.getClass()` returns the host-VM class object of the peer
(`gov.nasa.jpf.vm.JPF_java_lang_Class`). Consequences:

* relative names (`"config.txt"`) were resolved against package
  `gov/nasa/jpf/vm/` of JPF itself — never found;
* absolute names (`"/pkg/config.txt"`) were searched on the **host VM
  classpath**, which does not contain the SUT's classpath entries;
* additionally, no package-relative name resolution was performed at all
  (the model passed the raw name through), unlike `Class.getResource()`,
  which already resolves names correctly.

### Why the fix belongs in these two places

JPF already has correct infrastructure for exactly this lookup:
`ClassLoaderInfo.findResource(resourceName)` iterates the **SUT's real
classpath elements** (directories *and* jars) and is what the working
`ClassLoader.getResource0()` path uses. The fix routes the stream request
through that machinery and reuses the existing name resolution helpers,
instead of duplicating any logic.

---

## Solution

### 1. Peer change — `JPF_java_lang_Class.java`

```java
@MJI
public int getByteArrayFromResourceStream__Ljava_lang_String_2___3B (
        MJIEnv env, int clsRef, int nameRef) {
  ClassInfo ci = env.getReferredClassInfo(clsRef);
  String name = env.getStringObject(nameRef);

  // look up in the classpath of the requesting (SUT) class
  String url = ci.getClassLoaderInfo().findResource(name);
  if (url == null){
    return MJIEnv.NULL;
  }

  try {
    InputStream is = new java.net.URL(url).openStream();
    byte[] content;
    try {
      content = is.readAllBytes();
    } finally {
      is.close();
    }
    return env.newByteArray(content);
  } catch (IOException x) {
    return MJIEnv.NULL;
  }
}
```

Key points:

* `clsRef` — the `Class` object the method was invoked on — now determines
  where resources are searched (`ci.getClassLoaderInfo().findResource(..)`),
  supporting directory entries as well as `jar:` entries.
* The contract of the native changed slightly: it now expects an
  **already-resolved, slash-separated absolute resource name** (see below).
* Read errors are reported as "resource unavailable" (`null`) instead of
  leaking a host-VM `RuntimeException` into the verified application.
* Both `<2do>` comments removed; original author attribution kept.

### 2. Model change — `src/classes/modules/java.base/java/lang/Class.java`

`getResourceAsStream()` now resolves names exactly like the neighboring
`getResource()` implementation already does:

```java
public InputStream getResourceAsStream (String name) {
  if (name == null) {
    throw new NullPointerException("name");
  }

  String resolvedName = getResolvedName(name);   // pkg-relative -> absolute, strip '/'
  String moduleName = getModuleName();
  if (moduleName != null) {                      // same module prefixing as getResource()
    if (isJPFClass())
      resolvedName = "modules/" + moduleName + "/" + resolvedName;
    else
      resolvedName = moduleName + "/" + resolvedName;
  }

  byte[] byteArray = getByteArrayFromResourceStream(resolvedName);
  if (byteArray == null) return null;
  return new ByteArrayInputStream(byteArray);
}
```

* relative names are prefixed with the requesting class's package path,
  leading `/` is stripped (`getResolvedName`, existing native);
* module-scoped resources use the same `"modules/"...` convention as
  `getResource()`;
* explicit `NullPointerException` on a `null` name matches standard JVM
  behavior (previously, the `null` reached host-VM code inside the native
  method and terminated the whole JPF run with `JPFNativePeerException`).

No changes to `java.lang.ClassLoader` or to `getResource()` were required —
both already behaved correctly.

---

## Behavior before / after

Lookup (requesting class `a.b.Foo`, resource `a/b/res.txt` on SUT cp):

| Lookup | Before | After |
|---|---|---|
| `Foo.class.getResourceAsStream("res.txt")`            | `null` | found, byte-exact content |
| `Foo.class.getResourceAsStream("/a/b/res.txt")`       | `null` | found, identical bytes |
| nested: `"sub/res.txt"`                                | `null` | found |
| resource inside a **jar** on the SUT classpath         | `null`\* | found (via `jar:` URL branch) |
| `OtherPkg.class.getResourceAsStream("res.txt")`        | wrong scope / `null` | `null` (correct scoping) |
| `"a/b/res.txt"` (fully qualified, **no** leading `/`)  | n/a | `null` — treated as package-relative per JVM spec |
| missing resource                                       | `null` | `null` |
| `getResourceAsStream(null)`                            | **JPF terminates** with `JPFNativePeerException` (host NPE inside the native method) | clean SUT-level `NullPointerException` |
| consistency `getResource(x)` vs `getResourceAsStream(x)` | divergent | agree on existence |

\* The pre-fix lookup ran against the *host JVM* classpath, so a jar entry was
accidentally findable only if the same jar also happened to be on the host
classpath of the process launching JPF — never through the SUT classpath.
All *before* values were verified empirically by rebuilding the pre-fix
sources and running an identical probe under JPF.

---

## Regression tests

New tests in `src/tests/gov/nasa/jpf/test/java/lang/ClassTest.java`.
Fixtures are created at test start next to the compiled test class, i.e. they
are guaranteed to be on the SUT classpath (`jpf-core.test_classpath`
contains `build/tests`) when JPF verifies the very same class.

| Test | Edge case covered |
|---|---|
| `getResourceAsStreamRelativeTest`     | relative name resolves against requesting class's package; exact byte round-trip incl. multi-line content |
| `getResourceAsStreamAbsoluteTest`     | absolute `/pkg/path` form returns identical bytes |
| `getResourceAsStreamNestedRelativeTest` | relative name containing subdirectories |
| `getResourceAsStreamNotFoundTest`     | missing absolute & relative names · **package scoping** (requesting from another class must not find it) · fully-qualified name without leading `/` treated as package-relative → not found |
| `getResourceAsStreamFromJarTest`      | lookup inside a jar classpath entry (`asm-9.5.jar` from `test_classpath`); verifies real classfile magic bytes `0xCAFEBABE` read from the entry |
| `getResourceAsStreamConsistencyTest`  | `getResource()` and `getResourceAsStream()` agree on existence for present and missing resources |
| `getResourceAsStreamNullNameTest`     | `null` name raises uncaught `NullPointerException` (`verifyUnhandledException`) |

Content comparison is deliberately done **byte-wise against pure-ASCII
expected values**: charset decoding under JPF has separate, pre-existing
limitations (orphan `java.lang.StringCoding.decode/encode` native peers —
e.g. `new String(bytes, UTF_8)` decodes non-ASCII as U+FFFD). That gap is
independent of resource loading and out of scope here; comparing raw bytes
keeps these tests focused and robust.

---

## Verification

* Full `ClassTest`: **46/46 Ok** (39 pre-existing + 7 new)
* Full regression suite (`./gradlew test --rerun-tasks`):
  * `parallelTest`: **1054 passed, 0 failed**
  * `singleThreadTest`: **15 passed, 0 failed**
* Standalone before/after repro (host JVM vs JPF): previously failed with
  `null` for both relative and absolute forms; now passes identically to the
  host JVM.

---

## Commits

1. `cb61b84` — fix: load Class.getResourceAsStream() from SUT classpath instead of peer location
2. `d13cf3c` — test: expand getResourceAsStream() regression tests with edge cases