### PR TITLE
fix: add SharedSecrets JavaSecurityPropertiesAccess for ObjectStreamTest (fixes 2 failing tests)

### DIFF
--- a/gradle/source-sets.gradle
+++ b/gradle/source-sets.gradle
@@ -45,6 +45,8 @@ compileClassesJava.options.compilerArgs += [
         '--patch-module', 'java.logging=' + files(sourceSets.modules.java.srcDirs).asPath + '/java.logging',
         '--patch-module', 'java.xml=' + files(sourceSets.modules.java.srcDirs).asPath + '/java.xml',
         '--add-exports', 'java.base/sun.net.www.protocol.http=ALL-UNNAMED',
+        '--add-exports', 'java.base/jdk.internal.access=ALL-UNNAMED',
+        '--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED',
         '--add-reads', 'java.base=ALL-UNNAMED'
 ]
 
@@ -53,6 +55,8 @@ compileModulesJava.options.compilerArgs += [
         '--patch-module', 'java.logging=' + files(sourceSets.modules.java.srcDirs).asPath + '/java.logging',
         '--patch-module', 'java.xml=' + files(sourceSets.modules.java.srcDirs).asPath + '/java.xml',
         '--add-exports', 'java.base/sun.net.www.protocol.http=ALL-UNNAMED',
+        '--add-exports', 'java.base/jdk.internal.access=ALL-UNNAMED',
+        '--add-exports', 'java.base/jdk.internal.misc=ALL-UNNAMED',
         '--add-reads', 'java.base=ALL-UNNAMED',
         '--module-source-path', files(sourceSets.modules.java.srcDirs).asPath
 ]

--- a/src/classes/modules/java.base/jdk/internal/access/JavaSecurityPropertiesAccess.java
+++ b/src/classes/modules/java.base/jdk/internal/access/JavaSecurityPropertiesAccess.java
@@ -1,0 +1,7 @@
+package jdk.internal.access;
+
+import java.util.Properties;
+
+public interface JavaSecurityPropertiesAccess {
+    Properties getInitialProperties();
+}

--- a/src/classes/modules/java.base/jdk/internal/access/SharedSecrets.java
+++ b/src/classes/modules/java.base/jdk/internal/access/SharedSecrets.java
@@ -1,0 +1,10 @@
+package jdk.internal.access;
+
+public class SharedSecrets {
+  private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;
+
+  public SharedSecrets() {}
+
+  public static JavaSecurityPropertiesAccess getJavaSecurityPropertiesAccess() { return javaSecurityPropertiesAccess; }
+  public static void setJavaSecurityPropertiesAccess(JavaSecurityPropertiesAccess access) { javaSecurityPropertiesAccess = access; }
+}

--- a/src/classes/modules/java.base/jdk/internal/misc/JavaSecurityPropertiesAccess.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/JavaSecurityPropertiesAccess.java
@@ -1,0 +1,7 @@
+package jdk.internal.misc;
+
+import java.util.Properties;
+
+public interface JavaSecurityPropertiesAccess {
+    Properties getInitialProperties();
+}

--- a/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
+++ b/src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java
@@ -67,6 +67,7 @@ public class SharedSecrets {
   private static JavaNetSocketAccess javaNetSocketAccess;
   private static JavaNetInetAddressAccess javaNetInetAddressAccess;
   private static JavaSecurityAccess javaSecurityAccess;
+  private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;
   // (required for EnumSet ops)
   public static JavaLangAccess getJavaLangAccess() {
     return javaLangAccess;
@@ -264,5 +265,13 @@ public class SharedSecrets {
 
   public static JavaNetUriAccess getJavaNetUriAccess() {
     return javaNetUriAccess;
+  }
+
+  public static void setJavaSecurityPropertiesAccess(JavaSecurityPropertiesAccess access) {
+    javaSecurityPropertiesAccess = access;
+  }
+
+  public static JavaSecurityPropertiesAccess getJavaSecurityPropertiesAccess() {
+    return javaSecurityPropertiesAccess;
   }
 }


### PR DESCRIPTION
## Summary
Fixes the 2 failing tests in `parallelTest` `1028` `1026 passed 2 failed`:

- `gov.nasa.jpf.test.java.io.ObjectStreamTest.testSimpleReadbackOk:85`
- `gov.nasa.jpf.test.java.io.ObjectStreamTest.testLambdaSerialization:140`

```
java.lang.NoSuchMethodException: jdk.internal.misc.SharedSecrets.setJavaSecurityPropertiesAccess(Ljdk/internal/misc/JavaSecurityPropertiesAccess;)V
 at java.security.Security.<clinit>(Security.java:88)
 at java.io.ObjectInputFilter$Config.<clinit>(ObjectInputFilter.java:259)
 at java.io.ObjectInputFilter$Config$0.run
 at java.security.AccessController.doPrivileged(AccessController.java:34)
 at java.io.ObjectInputStream.<init>(ObjectInputStream.java:373)
 at gov.nasa.jpf.test.java.io.ObjectStreamTest.testSimpleReadbackOk(ObjectStreamTest.java:88)
```

Closes part of `parallelTest` `BUILD FAILED` on `master` `df58f6e` and `PR 638` `fix/jarfile-model`.

## Root Cause
`Security` `ObjectInputFilter` `clinit` calls `SharedSecrets.setJavaSecurityPropertiesAccess` via `jdk.internal.access` (Java 11, `Security.java:88` `invokestatic jdk/internal/access/SharedSecrets.setJavaSecurityPropertiesAccess`) and `jdk.internal.misc` (Java 8 compat). `jpf-core` `src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java:50` and missing `src/classes/modules/java.base/jdk/internal/access/SharedSecrets.java` had no `javaSecurityPropertiesAccess` field/method.

- `src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java` only `javaUtilJarAccess` `javaLangAccess` etc., missing `javaSecurityPropertiesAccess`
- `src/classes/modules/java.base/jdk/internal/access/` **missing** entirely (only `misc` exists `ls jdk/internal/access` empty)

Host `ZipFile` `JavaUtilZipFileAccess` already handled via `misc` `JUZFA` but `Security` needs `access`.

## Implementation
- `src/classes/modules/java.base/jdk/internal/access/JavaSecurityPropertiesAccess.java` `new` `interface JavaSecurityPropertiesAccess { Properties getInitialProperties(); }`
- `src/classes/modules/java.base/jdk/internal/access/SharedSecrets.java` `new` `minimal` `private static JavaSecurityPropertiesAccess javaSecurityPropertiesAccess;` `get/set`
- `src/classes/modules/java.base/jdk/internal/misc/JavaSecurityPropertiesAccess.java` `new` same
- `src/classes/modules/java.base/jdk/internal/misc/SharedSecrets.java:50` `+ field javaSecurityPropertiesAccess` `+ set/get`
- `gradle/source-sets.gradle:51` `compileModulesJava` `+ '--add-exports', 'java.base/jdk.internal.access=ALL-UNNAMED'` `+ 'jdk.internal.misc=ALL-UNNAMED'` `compileClassesJava` same

Keeps `sourceCompatibility 11` `VERSION_11` `major55`.

## Testing
```bash
export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
./gradlew clean
./gradlew parallelTest --tests "*ObjectStreamTest*"
# 9 tests 9 passed 0 failed (was 7 passed 2 failed)
./gradlew parallelTest
# 1028 tests 1028 passed 0 failed (was 1026/2)
```